### PR TITLE
Improved reservation form field error accessibility.

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -44,6 +44,7 @@
   "common.cancel": "Cancel",
   "common.cancelled": "Cancelled",
   "common.cancelling": "Cancelling...",
+  "common.checkError": "Error: ",
   "common.comments": "Comments",
   "common.commentsLabel": "Comments",
   "common.commentsPlaceholder": "Any additional information about the reservation",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -46,6 +46,7 @@
   "common.cancel": "Peru",
   "common.cancelled": "Peruttu",
   "common.cancelling": "Perutaan...",
+  "common.checkError": "Tarkista: ",
   "common.comments": "Kommentit",
   "common.commentsLabel": "Kommentit",
   "common.commentsPlaceholder": "Varauksen mahdolliset lisätiedot",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -46,6 +46,7 @@
   "common.cancel": "Avbryt",
   "common.cancelled": "Avbokad",
   "common.cancelling": "Avbokas...",
+  "common.checkError": "Kontrollera: ",
   "common.comments": "Kommentarer",
   "common.commentsLabel": "Kommentarer",
   "common.commentsPlaceholder": "Eventuell ytterligare information om bokningen",

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -98,6 +98,7 @@ export function validate(values, {
 
 class UnconnectedReservationInformationForm extends Component {
   renderField(name, type, label, controlProps = {}, help = null, info = null, altCheckbox = false) {
+    const { t } = this.props;
     if (!includes(this.props.fields, name)) {
       return null;
     }
@@ -111,6 +112,7 @@ class UnconnectedReservationInformationForm extends Component {
         help={help}
         info={info}
         label={`${label}${isRequired ? '*' : ''}`}
+        labelErrorPrefix={t('common.checkError')}
         name={name}
         type={type}
       />

--- a/app/shared/form-fields/FormControl.js
+++ b/app/shared/form-fields/FormControl.js
@@ -9,11 +9,14 @@ import HelpBlock from 'react-bootstrap/lib/HelpBlock';
 import InfoPopover from 'shared/info-popover';
 
 function FormControl({
-  controlProps = {}, help, id, info, label, type, validationState
+  controlProps = {}, help, id, info, label, labelErrorPrefix, type, validationState
 }) {
+  const helpBlockId = `${id}-help-block`;
+
   return (
     <FormGroup controlId={id} validationState={validationState}>
       <Col componentClass={ControlLabel} sm={3}>
+        {validationState && labelErrorPrefix}
         {label}
         {' '}
         {info && <InfoPopover id={`${id}-info`} placement="right" text={info} />}
@@ -21,10 +24,12 @@ function FormControl({
       <Col sm={9}>
         <RBFormControl
           {...controlProps}
+          aria-describedby={helpBlockId}
+          aria-invalid={validationState ? 'true' : 'false'}
           componentClass={type === 'textarea' ? 'textarea' : undefined}
           type={type !== 'textarea' ? type : undefined}
         />
-        {help && <HelpBlock>{help}</HelpBlock>}
+        <HelpBlock id={helpBlockId}>{help}</HelpBlock>
       </Col>
     </FormGroup>
   );
@@ -36,6 +41,7 @@ FormControl.propTypes = {
   id: PropTypes.string.isRequired,
   info: PropTypes.string,
   label: PropTypes.string.isRequired,
+  labelErrorPrefix: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   validationState: PropTypes.string,
 };

--- a/app/shared/form-fields/FormControl.spec.js
+++ b/app/shared/form-fields/FormControl.spec.js
@@ -14,6 +14,7 @@ describe('shared/form-fields/FormControl', () => {
     controlProps: { someProp: 'some', otherProp: 'other' },
     id: 'email',
     label: 'Enter your email',
+    labelErrorPrefix: 'Error: ',
     type: 'text',
     validationState: 'error',
   };
@@ -57,6 +58,20 @@ describe('shared/form-fields/FormControl', () => {
         ).toEqual(expect.arrayContaining([defaultProps.label]));
       });
 
+      describe('labelErrorPrefix text', () => {
+        test('is included in label text when field has an error', () => {
+          expect(
+            getColWrapper().props().children
+          ).toEqual(expect.arrayContaining([defaultProps.labelErrorPrefix]));
+        });
+
+        test('is not included in label text when field doesnt have an error', () => {
+          expect(
+            getColWrapper({ validationState: undefined }).props().children
+          ).toEqual(expect.not.arrayContaining([defaultProps.labelErrorPrefix]));
+        });
+      });
+
       test('does not contain InfoPopover if info not given', () => {
         const popover = getColWrapper().find(InfoPopover);
         expect(popover).toHaveLength(0);
@@ -94,6 +109,24 @@ describe('shared/form-fields/FormControl', () => {
       expect(rbFormControl.length).toBe(1);
     });
 
+    describe('when input error has occurred', () => {
+      test('gets correct aria props', () => {
+        const rbFormControl = getWrapper({ validationState: 'error' }).find(RBFormControl);
+        expect(rbFormControl.length).toBe(1);
+        expect(rbFormControl.prop('aria-invalid')).toBe('true');
+        expect(rbFormControl.prop('aria-describedby')).toEqual(`${defaultProps.id}-help-block`);
+      });
+    });
+
+    describe('when input error has not occurred', () => {
+      test('gets correct aria props', () => {
+        const rbFormControl = getWrapper({ validationState: undefined }).find(RBFormControl);
+        expect(rbFormControl.length).toBe(1);
+        expect(rbFormControl.prop('aria-invalid')).toBe('false');
+        expect(rbFormControl.prop('aria-describedby')).toEqual(`${defaultProps.id}-help-block`);
+      });
+    });
+
     describe('when type of the control is "textarea"', () => {
       test('gets correct props', () => {
         const type = 'textarea';
@@ -119,27 +152,17 @@ describe('shared/form-fields/FormControl', () => {
   });
 
   describe('HelpBlock component', () => {
-    describe('if help is given in props', () => {
-      const help = 'some help';
+    const help = 'some help';
 
-      test('is rendered', () => {
-        const helpBlock = getWrapper({ help }).find(HelpBlock);
-        expect(helpBlock.length).toBe(1);
-      });
-
-      test('displays the help text given in props', () => {
-        const helpBlock = getWrapper({ help }).find(HelpBlock);
-        expect(helpBlock.props().children).toBe(help);
-      });
+    test('is rendered', () => {
+      const helpBlock = getWrapper({ help }).find(HelpBlock);
+      expect(helpBlock.length).toBe(1);
+      expect(helpBlock.prop('id')).toEqual(`${defaultProps.id}-help-block`);
     });
 
-    describe('if help is not given in props', () => {
-      const help = undefined;
-
-      test('is not rendered', () => {
-        const helpBlock = getWrapper({ help }).find(HelpBlock);
-        expect(helpBlock.length).toBe(0);
-      });
+    test('displays the help text given in props', () => {
+      const helpBlock = getWrapper({ help }).find(HelpBlock);
+      expect(helpBlock.props().children).toBe(help);
     });
   });
 });

--- a/app/shared/form-fields/ReduxFormField.js
+++ b/app/shared/form-fields/ReduxFormField.js
@@ -6,7 +6,7 @@ import FormControl from './FormControl';
 import FormControlCheckbox from './FormControlCheckbox';
 
 function ReduxFormField({
-  controlProps = {}, help, info, input, label, meta, type, altCheckbox
+  controlProps = {}, help, info, input, label, labelErrorPrefix, meta, type, altCheckbox
 }) {
   const showError = meta.error && meta.touched;
   const props = {
@@ -15,6 +15,7 @@ function ReduxFormField({
     id: input.name,
     info,
     label,
+    labelErrorPrefix,
     type,
     validationState: showError ? 'error' : undefined,
   };
@@ -37,6 +38,7 @@ ReduxFormField.propTypes = {
   info: PropTypes.string,
   input: PropTypes.object.isRequired,
   label: PropTypes.string.isRequired,
+  labelErrorPrefix: PropTypes.string.isRequired,
   meta: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired,
 };

--- a/app/shared/form-fields/ReduxFormField.spec.js
+++ b/app/shared/form-fields/ReduxFormField.spec.js
@@ -12,6 +12,7 @@ describe('shared/form-fields/ReduxFormField', () => {
     controlProps: { someProp: 'some', otherProp: 'other' },
     input: { name: 'email' },
     label: 'Enter your email',
+    labelErrorPrefix: 'Error: ',
     meta: { error: 'some error' },
     name: 'email',
     type: 'text',
@@ -104,6 +105,11 @@ describe('shared/form-fields/ReduxFormField', () => {
     test('label is the label given in props', () => {
       const actualProps = getWrapper().find(FormControl).props();
       expect(actualProps.label).toBe(defaultProps.label);
+    });
+
+    test('labelErrorPrefix is the labelErrorPrefix given in props', () => {
+      const actualProps = getWrapper().find(FormControl).props();
+      expect(actualProps.labelErrorPrefix).toBe(defaultProps.labelErrorPrefix);
     });
 
     test('type is the type given in props', () => {

--- a/app/shared/reservation-confirmation/ReservationForm.js
+++ b/app/shared/reservation-confirmation/ReservationForm.js
@@ -100,6 +100,7 @@ export function validate(values, {
 
 class UnconnectedReservationForm extends Component {
   renderField(name, type, label, controlProps = {}, help = null, info = null, altCheckbox = false) {
+    const { t } = this.props;
     if (!includes(this.props.fields, name)) {
       return null;
     }
@@ -113,6 +114,7 @@ class UnconnectedReservationForm extends Component {
         help={help}
         info={info}
         label={`${label}${isRequired ? '*' : ''}`}
+        labelErrorPrefix={t('common.checkError')}
         name={name}
         type={type}
       />


### PR DESCRIPTION
Most notable changes:

- added error check prefix to form field label when validation error occurred e.g "Error: Email"
- added aria-invalid attribute to form fields
- linked each form field with their error message with aria-describedby attribute