### PR TITLE
Fix/var63 hamburger usability with keyboard

### DIFF
--- a/app/shared/main-navbar/MainNavbar.js
+++ b/app/shared/main-navbar/MainNavbar.js
@@ -40,10 +40,11 @@ class MainNavbar extends React.Component {
     return (
       <Navbar aria-label={t('Navbar.aria.mainNavbar.title')} className={classNames('app-MainNavbar', contrast)} expanded={this.state.expanded} onToggle={() => this.toggleCollapse()}>
         <Navbar.Header>
-          <Navbar.Toggle aria-label={t('Navbar.aria.topNavbar.mobileToggle')} />
           <Navbar.Brand>
             <Link to="/">Varaamo</Link>
           </Navbar.Brand>
+          <Navbar.Toggle aria-label={t('Navbar.aria.topNavbar.mobileToggle')} />
+
         </Navbar.Header>
         <Navbar.Collapse>
           <Nav activeKey={activeLink}>

--- a/app/shared/main-navbar/_main-navbar.scss
+++ b/app/shared/main-navbar/_main-navbar.scss
@@ -34,7 +34,7 @@ $externalIconMarginLeft: 5px;
     color: $white;
   }
 
-  .navbar-brand {
+  .navbar-brand, .navbar-toggle {
     font-size: inherit;
 
     @include add-focus(){
@@ -92,6 +92,7 @@ $externalIconMarginLeft: 5px;
 
     .navbar-brand,
     .navbar-brand:hover,
+    .navbar-toggle,
     .navbar-toggle .icon-bar {
       color: $black;
     }

--- a/app/shared/main-navbar/_main-navbar.scss
+++ b/app/shared/main-navbar/_main-navbar.scss
@@ -33,6 +33,9 @@ $externalIconMarginLeft: 5px;
   .navbar-toggle .icon-bar {
     color: $white;
   }
+  .navbar-toggle .icon-bar {
+    background-color: $white;
+  }
 
   .navbar-brand, .navbar-toggle {
     font-size: inherit;
@@ -95,6 +98,9 @@ $externalIconMarginLeft: 5px;
     .navbar-toggle,
     .navbar-toggle .icon-bar {
       color: $black;
+    }
+    .navbar-toggle .icon-bar {
+      background-color: $black;
     }
   }
 

--- a/app/shared/top-navbar/TopNavbar.js
+++ b/app/shared/top-navbar/TopNavbar.js
@@ -38,6 +38,7 @@ class TopNavbar extends Component {
     };
 
     this.handleLoginClick = this.handleLoginClick.bind(this);
+    this.toggleMobileNavbar = this.toggleMobileNavbar.bind(this);
   }
 
   componentDidUpdate(prevState) {
@@ -123,7 +124,7 @@ class TopNavbar extends Component {
                 aria-controls="mobileNavbar"
                 aria-label={t('Navbar.aria.topNavbar.mobileAccessibility')}
                 className="navbar-toggle"
-                onClick={() => this.toggleMobileNavbar()}
+                onClick={this.toggleMobileNavbar}
                 type="button"
               >
                 <div

--- a/app/shared/top-navbar/TopNavbar.js
+++ b/app/shared/top-navbar/TopNavbar.js
@@ -40,6 +40,13 @@ class TopNavbar extends Component {
     this.handleLoginClick = this.handleLoginClick.bind(this);
   }
 
+  componentDidUpdate(prevState) {
+    if (!prevState.expandMobileNavbar && this.state.expandMobileNavbar) {
+      document.getElementById('contrastButton').focus();
+      event.preventDefault();
+    }
+  }
+
   collapseItem() {
     this.setState({ expanded: false });
   }
@@ -92,36 +99,42 @@ class TopNavbar extends Component {
               </Link>
             </Navbar.Brand>
             <div className="mobile-buttons">
-              <button className="navbar-toggle lang" data-target="#mobile" data-toggle="collapse" type="button">
+              <button className="navbar-toggle lang" data-target="#mobile" data-toggle="collapse" tabIndex="-1" type="button">
                 <div aria-label={t('Navbar.aria.topNavbar.mobileLocale')} className="mobile_lang" role="list" type="button">
                   <NavDropdown
                     className="mobile_lang_dropdown"
                     eventKey="lang"
                     id="mobile"
-                    noCaret
                     onSelect={changeLocale}
-                    tabIndex="0"
                     title={currentLanguage}
                   >
-                    {currentLanguage !== 'fi' && <MenuItem eventKey="fi">FI</MenuItem>}
-                    {currentLanguage !== 'sv' && <MenuItem eventKey="sv">SV</MenuItem>}
+                    {currentLanguage === 'fi'
+                      ? (<MenuItem active aria-label="Suomi" eventKey="fi">FI</MenuItem>)
+                      : (<MenuItem aria-label="Suomi" eventKey="fi">FI</MenuItem>)
+                    }
+                    {currentLanguage === 'sv'
+                      ? (<MenuItem active aria-label="Svenska" eventKey="sv">SV</MenuItem>)
+                      : (<MenuItem aria-label="Svenska" eventKey="sv">SV</MenuItem>)
+                    }
                   </NavDropdown>
                 </div>
               </button>
-              <button aria-controls="mobileNavbar" aria-label={t('Navbar.aria.topNavbar.mobileAccessibility')} className="navbar-toggle" type="button">
+              <button
+                aria-controls="mobileNavbar"
+                aria-label={t('Navbar.aria.topNavbar.mobileAccessibility')}
+                className="navbar-toggle"
+                onClick={() => this.toggleMobileNavbar()}
+                type="button"
+              >
                 <div
                   className="mobile_accessibility"
-                  onClick={() => this.toggleMobileNavbar()}
-                  onKeyDown={ev => ((ev.keyCode === 13) ? (this.toggleMobileNavbar()) : '')}
-                  tabIndex="0"
-                  type="button"
                 >
                   <FontAwesomeIcon icon={faWheelchair} />
                 </div>
               </button>
 
               <Navbar.Toggle aria-label={t('Navbar.aria.topNavbar.mobileLogin')} data-target="#navCollapse">
-                <div className="mobile_login" tabIndex="0" type="button">
+                <div className="mobile_login">
                   <FontAwesomeIcon icon={faUserAlt} />
                 </div>
               </Navbar.Toggle>
@@ -137,13 +150,19 @@ class TopNavbar extends Component {
                 className="app-TopNavbar__language"
                 eventKey="lang"
                 id="language-nav-dropdown"
-                noCaret
                 onSelect={changeLocale}
                 tabIndex="0"
                 title={currentLanguage}
               >
-                {currentLanguage !== 'fi' && <MenuItem eventKey="fi">FI</MenuItem>}
-                {currentLanguage !== 'sv' && <MenuItem eventKey="sv">SV</MenuItem>}
+                {currentLanguage === 'fi'
+                  ? (<MenuItem active aria-label="Suomi" eventKey="fi">FI</MenuItem>)
+                  : (<MenuItem aria-label="Suomi" eventKey="fi">FI</MenuItem>)
+                    }
+                {currentLanguage === 'sv'
+                  ? (<MenuItem active aria-label="Svenska" eventKey="sv">SV</MenuItem>)
+                  : (<MenuItem aria-label="Svenska" eventKey="sv">SV</MenuItem>)
+                    }
+
               </NavDropdown>
 
               {isLoggedIn && (

--- a/app/shared/top-navbar/TopNavbar.js
+++ b/app/shared/top-navbar/TopNavbar.js
@@ -86,43 +86,46 @@ class TopNavbar extends Component {
         <Navbar aria-label={t('Navbar.aria.topNavbar.title')} className={classNames('app-TopNavbar', contrast)} expanded={this.state.expanded} onToggle={() => this.toggleCollapse()}>
 
           <Navbar.Header>
-            <Navbar.Toggle aria-label={t('Navbar.aria.topNavbar.mobileLogin')} data-target="#navCollapse">
-              <div className="mobile_login" tabIndex="0" type="button">
-                <FontAwesomeIcon icon={faUserAlt} />
-              </div>
-            </Navbar.Toggle>
-            <button aria-controls="mobileNavbar" aria-label={t('Navbar.aria.topNavbar.mobileAccessibility')} className="navbar-toggle" type="button">
-              <div
-                className="mobile_accessibility"
-                onClick={() => this.toggleMobileNavbar()}
-                onKeyDown={ev => ((ev.keyCode === 13) ? (this.toggleMobileNavbar()) : '')}
-                tabIndex="0"
-                type="button"
-              >
-                <FontAwesomeIcon icon={faWheelchair} />
-              </div>
-            </button>
-            <button className="navbar-toggle lang" data-target="#mobile" data-toggle="collapse" type="button">
-              <div aria-label={t('Navbar.aria.topNavbar.mobileLocale')} className="mobile_lang" role="list" type="button">
-                <NavDropdown
-                  className="mobile_lang_dropdown"
-                  eventKey="lang"
-                  id="mobile"
-                  noCaret
-                  onSelect={changeLocale}
-                  tabIndex="0"
-                  title={currentLanguage}
-                >
-                  {currentLanguage !== 'fi' && <MenuItem eventKey="fi">FI</MenuItem>}
-                  {currentLanguage !== 'sv' && <MenuItem eventKey="sv">SV</MenuItem>}
-                </NavDropdown>
-              </div>
-            </button>
             <Navbar.Brand>
               <Link aria-label={t('Navbar.aria.topNavbar.frontpage')} id="main" to="/">
                 <span aria-label="Turun vaakuna" className={`${currentLogo}`} title="Etusivu" />
               </Link>
             </Navbar.Brand>
+            <div className="mobile-buttons">
+              <button className="navbar-toggle lang" data-target="#mobile" data-toggle="collapse" type="button">
+                <div aria-label={t('Navbar.aria.topNavbar.mobileLocale')} className="mobile_lang" role="list" type="button">
+                  <NavDropdown
+                    className="mobile_lang_dropdown"
+                    eventKey="lang"
+                    id="mobile"
+                    noCaret
+                    onSelect={changeLocale}
+                    tabIndex="0"
+                    title={currentLanguage}
+                  >
+                    {currentLanguage !== 'fi' && <MenuItem eventKey="fi">FI</MenuItem>}
+                    {currentLanguage !== 'sv' && <MenuItem eventKey="sv">SV</MenuItem>}
+                  </NavDropdown>
+                </div>
+              </button>
+              <button aria-controls="mobileNavbar" aria-label={t('Navbar.aria.topNavbar.mobileAccessibility')} className="navbar-toggle" type="button">
+                <div
+                  className="mobile_accessibility"
+                  onClick={() => this.toggleMobileNavbar()}
+                  onKeyDown={ev => ((ev.keyCode === 13) ? (this.toggleMobileNavbar()) : '')}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <FontAwesomeIcon icon={faWheelchair} />
+                </div>
+              </button>
+
+              <Navbar.Toggle aria-label={t('Navbar.aria.topNavbar.mobileLogin')} data-target="#navCollapse">
+                <div className="mobile_login" tabIndex="0" type="button">
+                  <FontAwesomeIcon icon={faUserAlt} />
+                </div>
+              </Navbar.Toggle>
+            </div>
           </Navbar.Header>
           <Navbar.Collapse id="navCollapse" role="presentation">
             <Nav aria-label={t('Navbar.aria.topNavbar.options')} pullRight role="list">

--- a/app/shared/top-navbar/TopNavbar.spec.js
+++ b/app/shared/top-navbar/TopNavbar.spec.js
@@ -19,6 +19,33 @@ describe('shared/top-navbar/TopNavbar', () => {
     return shallowWithIntl(<TopNavbar {...defaults} {...props} />);
   }
 
+  describe('componentDidUpdate', () => {
+    let element;
+    let instance;
+    let spy;
+    beforeEach(() => {
+      element = getWrapper();
+      instance = getWrapper().instance();
+      spy = jest.spyOn(instance, 'componentDidUpdate');
+    });
+    test('has been called when !expandMobileNavbar -> expandMobileNavbar', () => {
+      expect(element.state('expandMobileNavbar')).toBe(false);
+      element.find('button').at(1).simulate('click');
+      expect(element.state('expandMobileNavbar')).toBe(true);
+      instance.componentDidUpdate({ expandMobileNavbar: false });
+      expect(spy).toHaveBeenCalled();
+    });
+
+    test('has been called when expandMobileNavbar -> !expandMobileNavbar', () => {
+      element.setState({ expandMobileNavbar: true });
+      expect(element.state('expandMobileNavbar')).toBe(true);
+      element.find('button').at(1).simulate('click');
+      expect(element.state('expandMobileNavbar')).toBe(false);
+      instance.componentDidUpdate({ expandMobileNavbar: true });
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
   describe('renders mobile, ', () => {
     test('renders MobileNavbar', () => {
       const element = getWrapper().find(MobileNavbar);
@@ -81,6 +108,7 @@ describe('shared/top-navbar/TopNavbar', () => {
         expect(element).toHaveLength(1);
         expect(element.prop('aria-controls')).toBe('mobileNavbar');
         expect(element.prop('className')).toBe('navbar-toggle');
+        expect(element.prop('onClick')).toBeDefined();
         expect(element.prop('type')).toBe('button');
       });
 

--- a/app/shared/top-navbar/TopNavbar.spec.js
+++ b/app/shared/top-navbar/TopNavbar.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import NavItem from 'react-bootstrap/lib/NavItem';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
+import NavDropdown from 'react-bootstrap/lib/NavDropdown';
 
 import { shallowWithIntl } from 'utils/testUtils';
 import TopNavbar from './TopNavbar';
@@ -10,6 +11,7 @@ describe('shared/top-navbar/TopNavbar', () => {
   function getWrapper(props) {
     const defaults = {
       changeLocale: () => null,
+      toggleMobileNavbar: () => null,
       currentLanguage: 'fi',
       isLoggedIn: false,
       userName: 'Luke Skywalker',
@@ -17,7 +19,7 @@ describe('shared/top-navbar/TopNavbar', () => {
     return shallowWithIntl(<TopNavbar {...defaults} {...props} />);
   }
 
-  describe('renders mobile', () => {
+  describe('renders mobile, ', () => {
     test('renders MobileNavbar', () => {
       const element = getWrapper().find(MobileNavbar);
       expect(element.length).toBe(1);
@@ -28,6 +30,65 @@ describe('shared/top-navbar/TopNavbar', () => {
       expect(first.length).toBe(2);
       const second = getWrapper().find('.navbar-toggle.lang');
       expect(second.length).toBe(1);
+    });
+
+    test('mobile-buttons div', () => {
+      const element = getWrapper().find('.mobile-buttons');
+      expect(element).toHaveLength(1);
+    });
+
+    describe('language dropdown ', () => {
+      function getLanguageDropdownWrap(props) {
+        return getWrapper(props).find('button').filter('.navbar-toggle').filter('.lang');
+      }
+
+      test('with correct props', () => {
+        const element = getLanguageDropdownWrap();
+        expect(element).toHaveLength(1);
+        expect(element.prop('className')).toBe('navbar-toggle lang');
+        expect(element.prop('tabIndex')).toBe('-1');
+        expect(element.prop('type')).toBe('button');
+      });
+
+      test('div with correct props', () => {
+        const element = getLanguageDropdownWrap().find('div');
+        expect(element).toHaveLength(1);
+        expect(element.prop('className')).toBe('mobile_lang');
+        expect(element.prop('type')).toBe('button');
+      });
+
+      test('NavDropdown with correct props', () => {
+        const changeLocale = () => null;
+        const currentLanguage = 'fi';
+        const nav = getLanguageDropdownWrap({ changeLocale, currentLanguage }).find(NavDropdown);
+
+        expect(nav).toHaveLength(1);
+        expect(nav.prop('className')).toBe('mobile_lang_dropdown');
+        expect(nav.prop('eventKey')).toBe('lang');
+        expect(nav.prop('id')).toBe('mobile');
+        expect(nav.prop('onSelect')).toBe(changeLocale);
+        expect(nav.prop('title')).toBe(currentLanguage);
+      });
+    });
+
+    describe('mobile accessibility', () => {
+      function getMobileA11yWrapper(props) {
+        return getWrapper(props).find('button').last();
+      }
+
+      test('button with correct props', () => {
+        const element = getMobileA11yWrapper();
+        expect(element).toHaveLength(1);
+        expect(element.prop('aria-controls')).toBe('mobileNavbar');
+        expect(element.prop('className')).toBe('navbar-toggle');
+        expect(element.prop('type')).toBe('button');
+      });
+
+      test('div with correct prop', () => {
+        const element = getMobileA11yWrapper().find('div');
+        expect(element).toHaveLength(1);
+        expect(element.prop('className')).toBe('mobile_accessibility');
+      });
     });
   });
 
@@ -46,11 +107,28 @@ describe('shared/top-navbar/TopNavbar', () => {
       expect(actual).toBe(changeLocale);
     });
 
-    test('renders MenuItems for other languages', () => {
+    test('renders correct MenuItems when language is Finnish', () => {
       const currentLanguage = 'fi';
       const menuItems = getLanguageNavWrapper({ currentLanguage }).find(MenuItem);
-      expect(menuItems).toHaveLength(1);
-      expect(menuItems.at(0).prop('eventKey')).toBe('sv');
+      expect(menuItems).toHaveLength(2);
+      expect(menuItems.at(0).prop('active')).toBe(true);
+      expect(menuItems.at(0).prop('aria-label')).toBe('Suomi');
+      expect(menuItems.at(0).prop('eventKey')).toBe('fi');
+      expect(menuItems.at(1).prop('active')).toBeUndefined();
+      expect(menuItems.at(1).prop('aria-label')).toBe('Svenska');
+      expect(menuItems.at(1).prop('eventKey')).toBe('sv');
+    });
+
+    test('renders correct MenuItems when language is Swedish', () => {
+      const currentLanguage = 'sv';
+      const menuItems = getLanguageNavWrapper({ currentLanguage }).find(MenuItem);
+      expect(menuItems).toHaveLength(2);
+      expect(menuItems.at(0).prop('active')).toBeUndefined();
+      expect(menuItems.at(0).prop('aria-label')).toBe('Suomi');
+      expect(menuItems.at(0).prop('eventKey')).toBe('fi');
+      expect(menuItems.at(1).prop('active')).toBe(true);
+      expect(menuItems.at(1).prop('aria-label')).toBe('Svenska');
+      expect(menuItems.at(1).prop('eventKey')).toBe('sv');
     });
   });
 

--- a/app/shared/top-navbar/_top-navbar.scss
+++ b/app/shared/top-navbar/_top-navbar.scss
@@ -395,6 +395,10 @@
 
     // Mobile
 
+  .mobile-buttons {
+    float: right;
+  }
+
   .mobile_lang_dropdown {
     list-style: none;
     text-transform: uppercase;
@@ -427,6 +431,7 @@
   }
   .navbar-toggle {
     margin-left: 15px;
+    float: none;
 
     &.lang {
       margin-left: 0;

--- a/app/shared/top-navbar/_top-navbar.scss
+++ b/app/shared/top-navbar/_top-navbar.scss
@@ -98,6 +98,39 @@
         display: block;
         cursor: default;
 
+        button {
+          border: 0;
+          background-color: transparent;
+          padding-left: 0px;
+          margin-left: 5px;
+          cursor: pointer;
+          @include add-focus;
+          &:hover {
+            text-decoration: none;
+          }
+
+          &.active {
+            text-decoration: underline;
+          }
+        }
+
+        // first
+        button:nth-child(1) {
+          font-size: 1em;
+        }
+
+        // second
+        button:nth-child(2) {
+          font-size: 1.25em;
+          line-height: 1.2;
+        }
+
+        // third
+        button:nth-child(3) {
+          font-size: 1.5em;
+          line-height: 1;
+        }
+
         span {
           padding-left: 0px;
           margin-left: 5px;
@@ -114,23 +147,6 @@
             text-decoration: underline;
           }
         }
-        // firstA
-        span:nth-child(1) {
-          font-size: 1em;
-        }
-
-        // secondA
-        span:nth-child(2) {
-          font-size: 1.25em;
-          line-height: 1.2;
-        }
-
-        // thirdA
-        span:nth-child(3) {
-          font-size: 1.5em;
-          line-height: 1;
-        }
-
       }
 
       &__contrast {
@@ -140,6 +156,8 @@
         margin-left: 15px;
 
         .contrast_button {
+          border: 0;
+          background-color: transparent;
           background-image: url('../../assets/icons/iconContrastSV.svg');
           background-size: 1.5em 1.5em;
           width: 1.5em;
@@ -178,10 +196,12 @@
 
         a#language-nav-dropdown {
           text-transform: uppercase;
-          padding-right:5px;
-          margin: 0 10px 0 15px;
+          margin: 0;
+          padding-left: 15px;
+          padding-right: 15px;
 
           @include add-focus;
+
         }
       }
 
@@ -193,7 +213,6 @@
 
     // Start: Remove responsive features from bootstrap nav to create a single-line top nav
     .navbar-header {
-//      float: left;
       margin-left: -15px;
       margin-right: -15px;
 
@@ -250,12 +269,16 @@
         bottom: 21px;
       }
 
+      >.active > #language-nav-dropdown:after,
+      > li > #language-nav-dropdown:hover:after {
+        border: none;
+      }
+
       .open .dropdown-menu {
         position: absolute;
         float: left;
         background-color: #ffffff;
-        border: 1px solid #ccc;
-        border: 1px solid rgba(0, 0, 0, 0.15);
+        border: none;
         box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
         min-width: 10px;
 
@@ -266,8 +289,22 @@
         }
 
         li > a {
+          margin: 0 auto;
+          text-align: center;
+          padding: 0.875em 0;
           @include add-focus(){
+            outline-offset: -3px;
             background-color: transparent;
+          }
+        }
+
+        .active > a {
+          background-color:lightgray;
+          @include add-focus(){
+            background-color:lightgray;
+          };
+          &:hover {
+            background-color: lightgray;
           }
         }
 
@@ -319,17 +356,11 @@
 
       .dropdown-menu {
         right: 0;
-        left: auto;
+        left: -2px;
         font-size: 1em;
       }
     }
     // End: Remove responsive features
-
-    &.navbar-default .navbar-nav .open .dropdown-menu > li > a:hover {
-      background-color: $white;
-    }
-
-
 
     // High-contrast
 
@@ -412,26 +443,37 @@
 
     .dropdown-menu {
       min-width: 10px;
-      right: -20px;
-      left:-20px;
+      right: -12px;
+      left: -12px;
       text-align: center;
       padding: 0;
       font-size: 1em;
+      margin-top: 12px;
 
       > li >a:hover,a:active,a:focus {
         color: $black;
         text-decoration: none;
-        background-color: $white;
+      }
+
+      > li.active > a, > li.active > a:focus{
+        background-color: lightgray;
       }
 
       > li > a{
         padding: 0.875em 0;
+        @include add-focus(){
+          outline-offset: -3px;
+        }
       }
     }
   }
   .navbar-toggle {
     margin-left: 15px;
     float: none;
+
+    &:focus-within {
+      @include focusElement;
+    }
 
     &.lang {
       margin-left: 0;
@@ -442,14 +484,6 @@
       cursor: pointer;
     }
   }
-
-  .dropdown-toggle:focus{
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px;
-    @include focusElement;
-  }
-
-
 
   .navbar-collapse > ul li.app-TopNavbar__language.dropdown,
   .navbar-collapse > ul li.navbar__font,

--- a/app/shared/top-navbar/accessibility/TopNavbarContrast.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarContrast.js
@@ -17,14 +17,6 @@ class ContrastChanger extends Component {
     };
   }
 
-
-  handleKeyDown = (ev) => {
-    if (ev.keyCode === 13) {
-      this.props.changeContrast();
-      this.toggleAriaState();
-    }
-  }
-
   handleOnClick = () => {
     this.props.changeContrast();
     this.toggleAriaState();
@@ -40,14 +32,14 @@ class ContrastChanger extends Component {
       <li className="navbar__contrast" role="presentation">
         <div aria-label={t('Nav.Contrast.title')} className="accessibility__contrast">
           {t('Nav.Contrast.title')}
-          <div
+          <button
             aria-label={t('Nav.Contrast.title')}
             aria-pressed={this.state.ariaState}
             className="contrast_button"
+            id="contrastButton"
             onClick={this.handleOnClick}
-            onKeyDown={this.handleKeyDown}
-            role="button"
             tabIndex="0"
+            type="button"
           />
         </div>
       </li>

--- a/app/shared/top-navbar/accessibility/TopNavbarContrast.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarContrast.js
@@ -17,11 +17,17 @@ class ContrastChanger extends Component {
     };
   }
 
+  /**
+   * Toggles page contrast and button aria-pressed value(false/true)
+   */
   handleOnClick = () => {
     this.props.changeContrast();
     this.toggleAriaState();
   }
 
+  /**
+   * Toggles state.ariaState
+   */
   toggleAriaState() {
     this.setState(prevState => ({ ariaState: !prevState.ariaState }));
   }

--- a/app/shared/top-navbar/accessibility/TopNavbarContrast.spec.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarContrast.spec.js
@@ -28,17 +28,16 @@ describe('shared/top-navbar/accessibility/TopNavbarContrast', () => {
     expect(text).toBe('Nav.Contrast.title');
   });
 
-  test('renders contrast_button', () => {
-    const element = content.find('.contrast_button');
+  test('renders contrast button', () => {
+    const element = content.find('button');
     expect(element.length).toBe(1);
   });
 
   describe('button', () => {
-    test('reacts to onKeyDown', () => {
+    test('reacts to onClick', () => {
       const changeContrast = simple.mock();
       const instance = getWrapper({ changeContrast }).instance();
-      const kbEvent = { keyCode: 13 };
-      instance.handleKeyDown(kbEvent);
+      instance.handleOnClick();
       expect(changeContrast.callCount).toBe(1);
     });
 
@@ -53,12 +52,13 @@ describe('shared/top-navbar/accessibility/TopNavbarContrast', () => {
     });
 
     test('has correct props', () => {
-      const element = content.find('div').last();
+      const element = content.find('button').last();
       expect(element.prop('aria-label')).toBe('Nav.Contrast.title');
       expect(element.prop('aria-pressed')).toBe(false);
       expect(element.prop('className')).toBe('contrast_button');
-      expect(element.prop('role')).toBe('button');
+      expect(element.prop('id')).toBe('contrastButton');
       expect(element.prop('tabIndex')).toBe('0');
+      expect(element.prop('type')).toBe('button');
     });
   });
 });

--- a/app/shared/top-navbar/accessibility/TopNavbarFontChanger.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarFontChanger.js
@@ -36,11 +36,20 @@ class FontSizeChanger extends Component {
   }
 
 
+  /**
+   * Checks if spanID is the active fontsize
+   * @param {string} spanID
+   */
   setActiveClass(spanID) {
     const span = this.getActiveFontButton(this.props.fontSize);
     return ((span === spanID) ? 'active' : '');
   }
 
+  /**
+   * Checks if spanID is the active fontsize
+   * @param {string} spanID
+   * @returns {Boolean} true/false
+   */
   setAriaPressed(spanID) {
     const span = this.getActiveFontButton(this.props.fontSize);
     return ((span === spanID));
@@ -50,6 +59,13 @@ class FontSizeChanger extends Component {
     this.props.changeFontSize(size);
   }
 
+  /**
+   *
+   * @param {string} spanID
+   * @param {string} fontSize
+   *
+   * @returns {html} <button> element
+   */
   renderFontButton(spanID, fontSize) {
     return (
       <button

--- a/app/shared/top-navbar/accessibility/TopNavbarFontChanger.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarFontChanger.js
@@ -20,7 +20,6 @@ class FontSizeChanger extends Component {
   constructor(props) {
     super(props);
     this.handleFontSizeClick = this.handleFontSizeClick.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   getActiveFontButton(size) {
@@ -47,29 +46,21 @@ class FontSizeChanger extends Component {
     return ((span === spanID));
   }
 
-  handleKeyDown(size, ev) {
-    if (ev.keyCode === 13) {
-      this.props.changeFontSize(size);
-    }
-  }
-
   handleFontSizeClick(size) {
     this.props.changeFontSize(size);
   }
 
   renderFontButton(spanID, fontSize) {
     return (
-      <span
+      <button
         aria-pressed={this.setAriaPressed(spanID)}
         className={this.setActiveClass(spanID)}
         onClick={() => this.handleFontSizeClick(fontSize)}
-        onKeyDown={ev => this.handleKeyDown(fontSize, ev)}
-        role="button"
-        tabIndex="0"
+        type="button"
       >
 A
 
-      </span>
+      </button>
     );
   }
 

--- a/app/shared/top-navbar/accessibility/TopNavbarFontChanger.spec.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarFontChanger.spec.js
@@ -29,34 +29,31 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
     expect(text).toContain('Nav.FontSize.title');
   });
 
-  test('renders buttonspan elements', () => {
-    const elements = content.find('span');
+  test('renders button elements', () => {
+    const elements = content.find('button');
     expect(elements.length).toBe(3);
   });
 
   describe('buttons have correct props at default', () => {
     test('first button', () => {
-      const element = content.find('span').first();
+      const element = content.find('button').first();
       expect(element.prop('aria-pressed')).toBe(true);
       expect(element.prop('className')).toBe('active');
-      expect(element.prop('role')).toBe('button');
-      expect(element.prop('tabIndex')).toBe('0');
+      expect(element.prop('type')).toBe('button');
     });
 
     test('second button', () => {
-      const element = content.find('span').at(1);
+      const element = content.find('button').at(1);
       expect(element.prop('aria-pressed')).toBe(false);
       expect(element.prop('className')).toBe('');
-      expect(element.prop('role')).toBe('button');
-      expect(element.prop('tabIndex')).toBe('0');
+      expect(element.prop('type')).toBe('button');
     });
 
     test('third button', () => {
-      const element = content.find('span').last();
+      const element = content.find('button').last();
       expect(element.prop('aria-pressed')).toBe(false);
       expect(element.prop('className')).toBe('');
-      expect(element.prop('role')).toBe('button');
-      expect(element.prop('tabIndex')).toBe('0');
+      expect(element.prop('type')).toBe('button');
     });
   });
 
@@ -77,47 +74,37 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
       expect(fontSize).toBe(instance.thirdA);
     });
   });
-  describe('span elements get active class when selected', () => {
-    test('first span get active', () => {
+  describe('button elements get active class when selected', () => {
+    test('first button get active', () => {
       content.setProps({ fontSize: ACC.FONT_SIZES.SMALL });
-      const element = content.find('span').at(0).find('.active');
+      const element = content.find('button').at(0).find('.active');
       expect(element.length).toBe(1);
     });
 
-    test('second span get active', () => {
+    test('second button get active', () => {
       content.setProps({ fontSize: ACC.FONT_SIZES.MEDIUM });
-      const element = content.find('span').at(1).find('.active');
+      const element = content.find('button').at(1).find('.active');
       expect(element.length).toBe(1);
     });
 
-    test('third span get active', () => {
+    test('third button get active', () => {
       content.setProps({ fontSize: ACC.FONT_SIZES.LARGE });
-      const element = content.find('span').at(2).find('.active');
+      const element = content.find('button').at(2).find('.active');
       expect(element.length).toBe(1);
     });
 
-    test('only one span is active', () => {
-      const element = content.find('span').find('.active');
+    test('only one button is active', () => {
+      const element = content.find('button').find('.active');
       expect(element.length).toBe(1);
     });
   });
 
-  describe('span onClicks work', () => {
+  describe('button onClicks work', () => {
     test('calls props.changeFontSize', () => {
       const changeFontSize = simple.mock();
       const instance = getWrapper({ changeFontSize }).instance();
       instance.handleFontSizeClick(ACC.FONT_SIZES.SMALL);
       expect(changeFontSize.callCount).toBe(1);
-      expect(changeFontSize.lastCall.args).toEqual([ACC.FONT_SIZES.SMALL]);
-    });
-  });
-
-  describe('span onKeyDown works', () => {
-    test('calls props.changeFontSize ', () => {
-      const changeFontSize = simple.mock();
-      const instance = getWrapper({ changeFontSize }).instance();
-      const kbEvent = { keyCode: 13 };
-      instance.handleKeyDown(ACC.FONT_SIZES.SMALL, kbEvent);
       expect(changeFontSize.lastCall.args).toEqual([ACC.FONT_SIZES.SMALL]);
     });
   });

--- a/app/shared/top-navbar/mobile/_mobile.scss
+++ b/app/shared/top-navbar/mobile/_mobile.scss
@@ -2,6 +2,10 @@
   .mobile-Navbar_mobile.is-collapsed {
     max-height:0;
     overflow: hidden;
+
+    ul > li {
+      display: none;
+    }
   }
 
   .mobile-Navbar_mobile {
@@ -39,38 +43,16 @@
         padding-top: 7px;
         padding-bottom: 7px;
 
-        span {
+        button {
+          border: 0;
+          background-color: transparent;
           padding-left: 5px;
           cursor: pointer;
+          @include add-focus;
 
           &.active {
             text-decoration: underline;
           }
-
-          &#firstA {
-            font-size: 1em;
-            padding-left: 30px;
-          }
-
-          &#secondA {
-            font-size: 1.25em;
-          }
-
-          &#thirdA {
-            font-size: 1.5em;
-          }
-        }
-        span:nth-child(1) {
-          font-size: 1em;
-          padding-left: 30px;
-        }
-
-        span:nth-child(2) {
-          font-size: 1.25em;
-        }
-
-        span:nth-child(3) {
-          font-size: 1.5em;
         }
         .contrast_button {
           filter: invert(100%);
@@ -80,6 +62,19 @@
 
     .accessibility__buttonGroup {
       line-height: 1;
+
+      button:nth-child(1) {
+        font-size: 1em;
+        margin-left: 30px;
+      }
+
+      button:nth-child(2) {
+        font-size: 1.25em;
+      }
+
+      button:nth-child(3) {
+        font-size: 1.5em;
+      }
     }
 
     .container{
@@ -92,8 +87,11 @@
     }
 
   .contrast_button {
+    border: 0;
+    background-color: transparent;
     background-image: url('../../../assets/icons/iconContrastSV.svg');
     background-size: 1.5em 1.5em;
+    color: $black;
     width: 1.5em;
     height: 1.5em;
     float: right;


### PR DESCRIPTION
Reworked the contrastchanger and fontchanger so that the buttons are actual <button> elements instead of <span>, Fixed the mobile view buttons(language/accessibility) so that tabbing to them works and looks correct. 
Clicking the mobile accessibility button moves the focus automatically to the contrast button, if the accessibility bar is already open it just closes the bar. 
Modified the language changer/dropdown so that it always displays both languages and adjusted the size of the actual dropdown list.