### PR TITLE
Fix/var65 link to main

### DIFF
--- a/app/assets/styles/_turku-custom-styles.scss
+++ b/app/assets/styles/_turku-custom-styles.scss
@@ -6,8 +6,13 @@ h1,h2,h3,h4,h5,h6,
 }
 
 html {
-//  letter-spacing: 0.12em;
-//  word-spacing: 0.16em;
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -321,6 +321,7 @@
   "SearchResultsPaging.previous": "Previous page",
   "SearchResultsPaging.section.name": "Search result page selector",
   "ShowResourcesLink.text": "Show all premises and equipment",
+  "SkipLink.text": "Skip to main content",
   "SortBy.label": "Sort By:",
   "SortBy.name.label": "Name",
   "SortBy.type.label": "Type",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -323,6 +323,7 @@
   "SearchResultsPaging.previous": "Edellinen sivu",
   "SearchResultsPaging.section.name": "Hakutulosten sivuvalitsin",
   "ShowResourcesLink.text": "Näytä kaikki tilat ja laitteet",
+  "SkipLink.text": "Siirry sisältöön",
   "SortBy.label": "Järjestä:",
   "SortBy.name.label": "Nimi",
   "SortBy.type.label": "Tyyppi",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -325,6 +325,7 @@
   "SearchResultsPaging.previous": "Föregående sida",
   "SearchResultsPaging.section.name": "Sökresultat sida väljare",
   "ShowResourcesLink.text": "Visa alla utrymmen och apparater",
+  "SkipLink.text": "Gå direkt till innehållet",
   "SortBy.label": "Sortera efter:",
   "SortBy.name.label": "Namn",
   "SortBy.type.label": "Typ",

--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -11,6 +11,7 @@ import { fetchUser } from 'actions/userActions';
 import Favicon from 'shared/favicon';
 import Footer from 'shared/footer';
 import Header from 'shared/header';
+import SkipLink from 'shared/skip-link';
 import TestSiteMessage from 'shared/test-site-message';
 import Notifications from 'shared/notifications';
 import { getCustomizationClassName } from 'utils/customizationUtils';
@@ -51,13 +52,15 @@ export class UnconnectedAppContainer extends Component {
     const { fontSize } = this.props;
     return (
       <div className={classNames('app', getCustomizationClassName(), (fontSize))}>
+        <SkipLink />
+
         <Helmet htmlAttributes={{ lang: this.props.currentLanguage }} title="Varaamo" />
 
         <Header location={this.props.location}>
           <Favicon />
           <TestSiteMessage />
         </Header>
-        <main aria-label="Main" className={classNames('app-content')}>
+        <main aria-label="Main" className={classNames('app-content')} id="main-content" tabIndex="-1">
           <Grid>
             <Notifications />
           </Grid>

--- a/app/pages/AppContainer.spec.js
+++ b/app/pages/AppContainer.spec.js
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet';
 
 import Header from 'shared/header';
 import Notifications from 'shared/notifications';
+import SkipLink from 'shared/skip-link';
 import { getState } from 'utils/testUtils';
 import * as customizationUtils from 'utils/customizationUtils';
 import { selector, UnconnectedAppContainer as AppContainer } from './AppContainer';
@@ -69,6 +70,10 @@ describe('pages/AppContainer', () => {
 
   describe('render', () => {
     const wrapper = getWrapper();
+
+    test('renders SkipLink', () => {
+      expect(getWrapper().find(SkipLink)).toHaveLength(1);
+    });
 
     test('renders Header', () => {
       expect(getWrapper().find(Header)).toHaveLength(1);

--- a/app/shared/_shared.scss
+++ b/app/shared/_shared.scss
@@ -25,6 +25,7 @@
 @import './resource-list/resource-list';
 @import './resource-card/resource-card';
 @import './resource-type-filter/resource-type-filter';
+@import './skip-link/skip-link';
 
 @import './test-site-message/test-site-message';
 

--- a/app/shared/skip-link/SkipLink.js
+++ b/app/shared/skip-link/SkipLink.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { injectT } from 'i18n';
+
+function SkipLink({ t }) {
+  return (
+    <a
+      className="visually-hidden skip-link"
+      href="#main-content"
+    >
+      {t('SkipLink.text')}
+    </a>
+  );
+}
+
+SkipLink.propTypes = {
+  t: PropTypes.func.isRequired,
+};
+
+export default injectT(SkipLink);

--- a/app/shared/skip-link/SkipLink.js
+++ b/app/shared/skip-link/SkipLink.js
@@ -5,12 +5,14 @@ import { injectT } from 'i18n';
 
 function SkipLink({ t }) {
   return (
-    <a
-      className="visually-hidden skip-link"
-      href="#main-content"
-    >
-      {t('SkipLink.text')}
-    </a>
+    <div className="accessibility-shortcuts">
+      <a
+        className="visually-hidden skip-link"
+        href="#main-content"
+      >
+        {t('SkipLink.text')}
+      </a>
+    </div>
   );
 }
 

--- a/app/shared/skip-link/SkipLink.spec.js
+++ b/app/shared/skip-link/SkipLink.spec.js
@@ -8,6 +8,12 @@ describe('shared/skip-link/SkipLink', () => {
     return shallowWithIntl(<SkipLink />);
   }
 
+  test('div container exists', () => {
+    const element = getWrapper().find('div');
+    expect(element).toHaveLength(1);
+    expect(element.prop('className')).toBe('accessibility-shortcuts');
+  });
+
   describe('SkipLink', () => {
     let element;
     beforeAll(() => {

--- a/app/shared/skip-link/SkipLink.spec.js
+++ b/app/shared/skip-link/SkipLink.spec.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { shallowWithIntl } from 'utils/testUtils';
+import SkipLink from './SkipLink';
+
+describe('shared/skip-link/SkipLink', () => {
+  function getWrapper() {
+    return shallowWithIntl(<SkipLink />);
+  }
+
+  describe('SkipLink', () => {
+    let element;
+    beforeAll(() => {
+      element = getWrapper().find('a');
+    });
+
+    test('renders', () => {
+      expect(element).toHaveLength(1);
+    });
+
+    test('renders with correct props', () => {
+      expect(element.prop('className')).toBe('visually-hidden skip-link');
+      expect(element.prop('href')).toBe('#main-content');
+    });
+
+    test('renders with text', () => {
+      expect(element.text()).toBeDefined();
+    });
+  });
+});

--- a/app/shared/skip-link/_skip-link.scss
+++ b/app/shared/skip-link/_skip-link.scss
@@ -1,16 +1,18 @@
-.visually-hidden {
-
-  &.skip-link {
-
-    &:focus,
-    &:active {
-      position: relative;
-      left: 0;
-      width: auto;
-      height: auto;
-      overflow: visible;
-      text-align: center;
-      background-color: lightgray;
+.accessibility-shortcuts{
+  text-align: center;
+  background-color:#37475e;
+  .visually-hidden {
+    &.skip-link {
+      &:focus,
+      &:active {
+        position: relative;
+        left: 0;
+        width: auto;
+        height: auto;
+        overflow: visible;
+        outline: none;
+        color:$white;
+      }
     }
   }
 }

--- a/app/shared/skip-link/_skip-link.scss
+++ b/app/shared/skip-link/_skip-link.scss
@@ -1,0 +1,16 @@
+.visually-hidden {
+
+  &.skip-link {
+
+    &:focus,
+    &:active {
+      position: relative;
+      left: 0;
+      width: auto;
+      height: auto;
+      overflow: visible;
+      text-align: center;
+      background-color: lightgray;
+    }
+  }
+}

--- a/app/shared/skip-link/index.js
+++ b/app/shared/skip-link/index.js
@@ -1,0 +1,3 @@
+import SkipLink from './SkipLink';
+
+export default SkipLink;


### PR DESCRIPTION
Added a new skip link component, the skip link appears in a bar on top of the site when tabbed in. Also added a new css rule that makes the scrolling smooth when using the skip link, it is disabled if the user has disabled animations in their browser/pc. https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior#Accessibility_concerns