### PR TITLE
Added aria-labels to font buttons

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -361,5 +361,8 @@
   "UserReservationsPage.regularReservationsHeader": "Standard reservations",
   "UserReservationsPage.title": "My reservations",
   "Nav.FontSize.title": "Fontsize",
+  "Nav.FontSize.small":"Small",
+  "Nav.FontSize.medium":"Medium",
+  "Nav.FontSize.large":"Large",
   "Nav.Contrast.title": "Contrast"
 }

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -363,5 +363,8 @@
   "UserReservationsPage.regularReservationsHeader": "Tavalliset varaukset",
   "UserReservationsPage.title": "Omat varaukset",
   "Nav.FontSize.title": "Tekstikoko",
+  "Nav.FontSize.small":"Pieni",
+  "Nav.FontSize.medium":"Keskisuuri",
+  "Nav.FontSize.large":"Suuri",
   "Nav.Contrast.title": "Kontrasti"
 }

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -365,5 +365,8 @@
   "UserReservationsPage.regularReservationsHeader": "Vanliga bokningar",
   "UserReservationsPage.title": "Mina bokningar",
   "Nav.FontSize.title": "Fontstorlek",
+  "Nav.FontSize.small":"Liten",
+  "Nav.FontSize.medium":"Medelstor",
+  "Nav.FontSize.large":"Stor",
   "Nav.Contrast.title": "Kontrast"
 }

--- a/app/shared/top-navbar/accessibility/TopNavbarFontChanger.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarFontChanger.js
@@ -11,11 +11,11 @@ class FontSizeChanger extends Component {
     changeFontSize: PropTypes.func,
   };
 
-  firstA = 'firstA';
+  first = 'first';
 
-  secondA = 'secondA';
+  second = 'second';
 
-  thirdA = 'thirdA';
+  third = 'third';
 
   constructor(props) {
     super(props);
@@ -25,13 +25,13 @@ class FontSizeChanger extends Component {
   getActiveFontButton(size) {
     switch (size) {
       case ACC.FONT_SIZES.SMALL:
-        return this.firstA;
+        return this.first;
       case ACC.FONT_SIZES.MEDIUM:
-        return this.secondA;
+        return this.second;
       case ACC.FONT_SIZES.LARGE:
-        return this.thirdA;
+        return this.third;
       default:
-        return this.firstA;
+        return this.first;
     }
   }
 
@@ -43,6 +43,27 @@ class FontSizeChanger extends Component {
   setActiveClass(spanID) {
     const span = this.getActiveFontButton(this.props.fontSize);
     return ((span === spanID) ? 'active' : '');
+  }
+
+  /**
+   * Returns correct text for the aria-label
+   * @param {*} size
+   */
+  setAriaLabel(size) {
+    const { t } = this.props;
+    switch (size) {
+      case ACC.FONT_SIZES.SMALL:
+        return t('Nav.FontSize.small');
+
+      case ACC.FONT_SIZES.MEDIUM:
+        return t('Nav.FontSize.medium');
+
+      case ACC.FONT_SIZES.LARGE:
+        return t('Nav.FontSize.large');
+
+      default:
+        return '';
+    }
   }
 
   /**
@@ -69,6 +90,7 @@ class FontSizeChanger extends Component {
   renderFontButton(spanID, fontSize) {
     return (
       <button
+        aria-label={this.setAriaLabel(fontSize)}
         aria-pressed={this.setAriaPressed(spanID)}
         className={this.setActiveClass(spanID)}
         onClick={() => this.handleFontSizeClick(fontSize)}
@@ -89,9 +111,9 @@ A
       <li className="navbar__font" role="presentation">
         <div aria-label={t('Nav.FontSize.title')} className="accessibility__buttonGroup">
           {t('Nav.FontSize.title')}
-          {this.renderFontButton(this.firstA, ACC.FONT_SIZES.SMALL)}
-          {this.renderFontButton(this.secondA, ACC.FONT_SIZES.MEDIUM)}
-          {this.renderFontButton(this.thirdA, ACC.FONT_SIZES.LARGE)}
+          {this.renderFontButton(this.first, ACC.FONT_SIZES.SMALL)}
+          {this.renderFontButton(this.second, ACC.FONT_SIZES.MEDIUM)}
+          {this.renderFontButton(this.third, ACC.FONT_SIZES.LARGE)}
         </div>
       </li>
 

--- a/app/shared/top-navbar/accessibility/TopNavbarFontChanger.spec.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarFontChanger.spec.js
@@ -37,6 +37,7 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
   describe('buttons have correct props at default', () => {
     test('first button', () => {
       const element = content.find('button').first();
+      expect(element.prop('aria-label')).toBe('Nav.FontSize.small');
       expect(element.prop('aria-pressed')).toBe(true);
       expect(element.prop('className')).toBe('active');
       expect(element.prop('type')).toBe('button');
@@ -44,6 +45,7 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
 
     test('second button', () => {
       const element = content.find('button').at(1);
+      expect(element.prop('aria-label')).toBe('Nav.FontSize.medium');
       expect(element.prop('aria-pressed')).toBe(false);
       expect(element.prop('className')).toBe('');
       expect(element.prop('type')).toBe('button');
@@ -51,6 +53,7 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
 
     test('third button', () => {
       const element = content.find('button').last();
+      expect(element.prop('aria-label')).toBe('Nav.FontSize.large');
       expect(element.prop('aria-pressed')).toBe(false);
       expect(element.prop('className')).toBe('');
       expect(element.prop('type')).toBe('button');
@@ -61,17 +64,17 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
     const instance = getWrapper().instance();
     test('fontsize is small', () => {
       const fontSize = instance.getActiveFontButton(ACC.FONT_SIZES.SMALL);
-      expect(fontSize).toBe(instance.firstA);
+      expect(fontSize).toBe(instance.first);
     });
 
     test('fontsize is medium', () => {
       const fontSize = instance.getActiveFontButton(ACC.FONT_SIZES.MEDIUM);
-      expect(fontSize).toBe(instance.secondA);
+      expect(fontSize).toBe(instance.second);
     });
 
     test('fontsize is large', () => {
       const fontSize = instance.getActiveFontButton(ACC.FONT_SIZES.LARGE);
-      expect(fontSize).toBe(instance.thirdA);
+      expect(fontSize).toBe(instance.third);
     });
   });
   describe('button elements get active class when selected', () => {
@@ -106,6 +109,62 @@ describe('shared/top-navbar/accessibility/TopNavbarFontChanger', () => {
       instance.handleFontSizeClick(ACC.FONT_SIZES.SMALL);
       expect(changeFontSize.callCount).toBe(1);
       expect(changeFontSize.lastCall.args).toEqual([ACC.FONT_SIZES.SMALL]);
+    });
+  });
+
+  describe('setActiveClass returns ', () => {
+    test('active when span === spanID', () => {
+      const spanID = 'second';
+      const instance = getWrapper({ fontSize: ACC.FONT_SIZES.MEDIUM }).instance();
+      const span = instance.setActiveClass(spanID);
+      expect(span).toBe('active');
+    });
+
+    test('"" when span !== spanID', () => {
+      const spanID = 'first';
+      const instance = getWrapper({ fontSize: ACC.FONT_SIZES.MEDIUM }).instance();
+      const span = instance.setActiveClass(spanID);
+      expect(span).toBe('');
+    });
+  });
+
+  describe('setAriaPressed returns ', () => {
+    test('true when span === spanID', () => {
+      const spanID = 'first';
+      const instance = getWrapper({ fontSize: ACC.FONT_SIZES.SMALL }).instance();
+      const span = instance.setAriaPressed(spanID);
+      expect(span).toBe(true);
+    });
+
+    test('false when span !== spanID', () => {
+      const spanID = 'second';
+      const instance = getWrapper({ fontSize: ACC.FONT_SIZES.SMALL }).instance();
+      const span = instance.setAriaPressed(spanID);
+      expect(span).toBe(false);
+    });
+  });
+
+  describe('setAriaLabel returns correct texts', () => {
+    const instance = getWrapper().instance();
+
+    test('to the small text button', () => {
+      const value = instance.setAriaLabel(ACC.FONT_SIZES.SMALL);
+      expect(value).toBe('Nav.FontSize.small');
+    });
+
+    test('to the medium text button', () => {
+      const value = instance.setAriaLabel(ACC.FONT_SIZES.MEDIUM);
+      expect(value).toBe('Nav.FontSize.medium');
+    });
+
+    test('to the large text button', () => {
+      const value = instance.setAriaLabel(ACC.FONT_SIZES.LARGE);
+      expect(value).toBe('Nav.FontSize.large');
+    });
+
+    test('default', () => {
+      const value = instance.setAriaLabel('error');
+      expect(value).toBe('');
     });
   });
 });


### PR DESCRIPTION
Added language-specific aria-labels to each font button, pieni/keskisuuri/suuri , liten/medelstor/stor. did some minor refactoring of the fontchanger. Added tests for the new stuff and added some new ones for functions that didnt have any.