### PR TITLE
Display resources according to staffPerms

### DIFF
--- a/app/pages/admin-resources/adminResourcesPageSelector.spec.js
+++ b/app/pages/admin-resources/adminResourcesPageSelector.spec.js
@@ -5,8 +5,27 @@ import adminResourcesPageSelector from './adminResourcesPageSelector';
 
 describe('pages/admin-resources/adminResourcesPageSelector', () => {
   function getSelected(extraState) {
-    const state = getState(extraState);
+    const state = getState(getUser(extraState));
     return adminResourcesPageSelector(state);
+  }
+
+  function getUser(extra) {
+    return {
+      'auth.user.profile': {
+        sub: '2019token'
+      },
+      'data.users.2019token': {
+        staffPerms: {
+          unit: {
+            unitID01: [
+              'can_make_reservations',
+              'can_modify_reservations',
+            ]
+          },
+        },
+      },
+      ...extra
+    };
   }
 
   test('returns isAdmin', () => {
@@ -40,9 +59,15 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   });
 
   test('returns an array of resource ids ordered by translated name', () => {
-    const resource1 = { id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' } };
-    const resource2 = { id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' } };
-    const resource3 = { id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' } };
+    const resource1 = {
+      id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
+    };
+    const resource2 = {
+      id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID01'
+    };
+    const resource3 = {
+      id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
+    };
     const extraState = {
       'data.resources': {
         [resource1.id]: resource1,
@@ -57,10 +82,47 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
     expect(selected.resources).toEqual(expected);
   });
 
+  test(
+    'returns array of resource ids consisting of resources that are in a unit where the user has staffPermissions',
+    () => {
+      const resource1 = {
+        id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
+      };
+      const resource2 = {
+        id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
+      };
+      const resource3 = {
+        id: 'resourceID03', name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
+      };
+      const resource4 = {
+        id: 'resourceID04', name: { fi: 'Dagobah' }, type: { name: 'printer' }, unit: 'unitID02'
+      };
+
+      const extraState = {
+        'data.resources': {
+          [resource1.id]: resource1,
+          [resource2.id]: resource2,
+          [resource3.id]: resource3,
+          [resource4.id]: resource4,
+        },
+        'ui.pages.adminResources.resourceIds': [resource1.id, resource2.id, resource3.id, resource4.id],
+      };
+      const selected = getSelected(extraState);
+      const expected = [resource3.id, resource1.id];
+      expect(selected.resources).toEqual(expected);
+    }
+  );
+
   test('returns an array of resourceTypes', () => {
-    const resource1 = { id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' } };
-    const resource2 = { id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' } };
-    const resource3 = { id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' } };
+    const resource1 = {
+      id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
+    };
+    const resource2 = {
+      id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID01'
+    };
+    const resource3 = {
+      id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
+    };
     const extraState = {
       'data.resources': {
         [resource1.id]: resource1,
@@ -74,12 +136,47 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
     expect(selected.resourceTypes).toEqual(expected);
   });
 
+  test('returns an array of resourceTypes according to user staff permissions', () => {
+    const resource1 = {
+      id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
+    };
+    const resource2 = {
+      id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
+    };
+    const resource3 = {
+      id: 'resourceID03', name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
+    };
+    const resource4 = {
+      id: 'resourceID04', name: { fi: 'Dagobah' }, type: { name: 'studio' }, unit: 'unitID01'
+    };
+
+    const extraState = {
+      'data.resources': {
+        [resource1.id]: resource1,
+        [resource2.id]: resource2,
+        [resource3.id]: resource3,
+        [resource4.id]: resource4,
+      },
+      'ui.pages.adminResources.resourceIds': [resource1.id, resource2.id, resource3.id, resource4.id],
+    };
+
+    const selected = getSelected(extraState);
+    const expected = ['school', 'printer', 'studio'];
+    expect(selected.resourceTypes).toEqual(expected);
+  });
+
   test(
     'returns an array of selectedResourceTypes and filtered resourceIds',
     () => {
-      const resource1 = { id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' } };
-      const resource2 = { id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' } };
-      const resource3 = { id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' } };
+      const resource1 = {
+        id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
+      };
+      const resource2 = {
+        id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID01'
+      };
+      const resource3 = {
+        id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
+      };
       const extraState = {
         'data.resources': {
           [resource1.id]: resource1,


### PR DESCRIPTION
Resources are now displayed if the resources unit is included in the users staff permissions object.
If the user has no staff permissions then the page will not show any resources.