### PR TITLE
Fixed scrolling

### DIFF
--- a/app/assets/styles/_turku-custom-styles.scss
+++ b/app/assets/styles/_turku-custom-styles.scss
@@ -6,7 +6,7 @@ h1,h2,h3,h4,h5,h6,
 }
 
 html {
-  scroll-behavior: smooth;
+  scroll-behavior: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -44,6 +44,7 @@ class UnconnectedResourcePage extends Component {
   componentDidMount() {
     this.props.actions.clearReservations();
     this.fetchResource();
+    window.scrollTo(0, 0);
   }
 
   componentWillUpdate(nextProps) {

--- a/app/pages/resource/ResourcePage.spec.js
+++ b/app/pages/resource/ResourcePage.spec.js
@@ -220,6 +220,19 @@ describe('pages/resource/ResourcePage', () => {
       expect(fetchResource.callCount).toBe(1);
       expect(fetchResource.lastCall.args).toEqual([]);
     });
+
+    test('calls window.scrollTo', () => {
+      const scrollToMock = simple.mock();
+      simple.mock(window, 'scrollTo', scrollToMock);
+      const instance = getWrapper().instance();
+      instance.componentDidMount();
+
+      expect(scrollToMock.callCount).toBe(1);
+      const args = scrollToMock.lastCall.args;
+      expect(args).toHaveLength(2);
+      expect(args[0]).toBe(0);
+      expect(args[1]).toBe(0);
+    });
   });
 
   describe('componentWillUpdate', () => {

--- a/app/pages/search/results/SearchResults.js
+++ b/app/pages/search/results/SearchResults.js
@@ -6,20 +6,10 @@ import { connect } from 'react-redux';
 import { injectT } from 'i18n';
 import ResourceCompactList from 'shared/resource-compact-list';
 import ResourceList from 'shared/resource-list';
-import { scrollTo } from 'utils/domUtils';
 import SearchResultsPaging from './SearchResultsPaging';
 import searchResultsSelector from './searchResultsSelector';
 
 export class UnconnectedSearchResults extends Component {
-  constructor(props) {
-    super(props);
-    this.searchResultsComponent = React.createRef();
-  }
-
-  componentDidMount() {
-    scrollTo(this.searchResultsComponent.current);
-  }
-
   render() {
     const {
       filters,
@@ -33,7 +23,7 @@ export class UnconnectedSearchResults extends Component {
       t,
     } = this.props;
     return (
-      <div className="app-SearchResults" id="search-results" ref={this.searchResultsComponent}>
+      <div className="app-SearchResults" id="search-results">
         <Loader loaded={!isFetching}>
           {!showMap && (
             <div className="app-SearchResults__container">


### PR DESCRIPTION
Resourcepages will now open scrolled to the top, previously the window scroll position of the search page was used as the scroll position on the resource pages. This caused resources to open already scrolled down according to the search pages scroll position.