### PR TITLE
added link to sv gitbook

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -20,6 +20,7 @@ export default {
   },
   NAV_ADMIN_URLS: {
     gitbook: 'https://digipoint-turku.gitbook.io/varaamo-turku/',
+    gitbook_sv: 'https://digipoint-turku.gitbook.io/varaamo-turku/v/v.1.0.0-swedish/',
     respa: SETTINGS.ADMIN_URL,
   },
   NOTIFICATION_DEFAULTS: {

--- a/app/shared/main-navbar/MainNavbar.js
+++ b/app/shared/main-navbar/MainNavbar.js
@@ -38,7 +38,11 @@ class MainNavbar extends React.Component {
       isLoggedIn,
       t,
       contrast,
+      currentLanguage,
     } = this.props;
+
+    const gitbookURL = currentLanguage === 'sv' ? constants.NAV_ADMIN_URLS.gitbook_sv : constants.NAV_ADMIN_URLS.gitbook;
+
     return (
       <Navbar aria-label={t('Navbar.aria.mainNavbar.title')} className={classNames('app-MainNavbar', contrast)} expanded={this.state.expanded} onToggle={() => this.toggleCollapse()}>
         <Navbar.Header>
@@ -91,7 +95,7 @@ class MainNavbar extends React.Component {
                     <FAIcon icon={faExternalLinkAlt} />
                   </NavItem>
 
-                  <NavItem eventKey="adminGuide" href={constants.NAV_ADMIN_URLS.gitbook} target="_blank">
+                  <NavItem eventKey="adminGuide" href={gitbookURL} target="_blank">
                     {t('Navbar.adminGuide')}
                     <FAIcon icon={faExternalLinkAlt} />
                   </NavItem>
@@ -117,6 +121,7 @@ MainNavbar.propTypes = {
   isLoggedIn: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,
   contrast: PropTypes.string,
+  currentLanguage: PropTypes.string,
 };
 
 export default injectT(MainNavbar);

--- a/app/shared/main-navbar/MainNavbar.spec.js
+++ b/app/shared/main-navbar/MainNavbar.spec.js
@@ -17,6 +17,7 @@ describe('shared/main-navbar/MainNavbar', () => {
     const defaults = {
       activeLink: pathname,
       changeLocale: () => null,
+      currentLanguage: 'fi',
       clearSearchResults: () => null,
       isAdmin: false,
       isLoggedIn: false,
@@ -109,9 +110,15 @@ describe('shared/main-navbar/MainNavbar', () => {
       expect(respaAdminLink.prop('target')).toEqual('_blank');
     });
 
-    test('renders a link to varaamo gitbook', () => {
+    test('renders a link to default(finnish) varaamo gitbook when language is not swedish', () => {
       const gitbookLink = getLoggedInAdminWrapper()
         .find(NavItem).filter({ href: constants.NAV_ADMIN_URLS.gitbook });
+      expect(gitbookLink).toHaveLength(1);
+    });
+
+    test('renders a link to swedish varaamo gitbook when language is swedish', () => {
+      const gitbookLink = getLoggedInAdminWrapper({ currentLanguage: 'sv' })
+        .find(NavItem).filter({ href: constants.NAV_ADMIN_URLS.gitbook_sv });
       expect(gitbookLink).toHaveLength(1);
     });
 

--- a/app/shared/main-navbar/MainNavbarContainer.js
+++ b/app/shared/main-navbar/MainNavbarContainer.js
@@ -5,6 +5,7 @@ import { clearSearchResults } from 'actions/searchActions';
 import { isAdminSelector, isLoggedInSelector } from 'state/selectors/authSelectors';
 import { contrastSelector } from 'state/selectors/accessibilitySelectors';
 import { changeLocale } from 'i18n';
+import { currentLanguageSelector } from 'state/selectors/translationSelectors';
 import MainNavbar from './MainNavbar';
 
 const contrastOptionsSelector = state => contrastSelector(state);
@@ -13,6 +14,7 @@ export const selector = createStructuredSelector({
   isAdmin: isAdminSelector,
   isLoggedIn: isLoggedInSelector,
   contrast: contrastOptionsSelector,
+  currentLanguage: currentLanguageSelector,
 });
 
 const actions = {

--- a/app/shared/main-navbar/MainNavbarContainer.spec.js
+++ b/app/shared/main-navbar/MainNavbarContainer.spec.js
@@ -34,5 +34,10 @@ describe('shared/main-navbar/MainNavbarContainer', () => {
       const selected = selector(getState());
       expect(selected.contrast).toBeDefined();
     });
+
+    test('returns currentLanguage', () => {
+      const selected = selector(getState());
+      expect(selected.currentLanguage).toBeDefined();
+    })
   });
 });

--- a/app/shared/main-navbar/MainNavbarContainer.spec.js
+++ b/app/shared/main-navbar/MainNavbarContainer.spec.js
@@ -38,6 +38,6 @@ describe('shared/main-navbar/MainNavbarContainer', () => {
     test('returns currentLanguage', () => {
       const selected = selector(getState());
       expect(selected.currentLanguage).toBeDefined();
-    })
+    });
   });
 });


### PR DESCRIPTION
added stuff so if the site language is swedish then the admin guide link in mainnavbar will link to a specific swedish version.For other languages the default finnish version is used instead.