### PR TITLE
Removed English from auto language detection

### DIFF
--- a/app/i18n/initI18n.js
+++ b/app/i18n/initI18n.js
@@ -60,8 +60,6 @@ function initI18n() {
     locale = persistedData;
   } else if (browserLanguage === 'sv' || browserLanguage === 'sv-fi' || browserLanguage === 'sv-se') {
     locale = 'se';
-  } else if (browserLanguage.includes('en')) {
-    locale = 'en';
   } else if (browserLanguage === 'fi') {
     locale = browserLanguage;
   } else {

--- a/app/i18n/initI18n.spec.js
+++ b/app/i18n/initI18n.spec.js
@@ -62,8 +62,8 @@ describe('initI18n', () => {
       const expected = {
         intl: {
           defaultLocale: constants.DEFAULT_LOCALE,
-          locale: 'en',
-          messages: messages.en,
+          locale: 'fi',
+          messages: messages.fi,
         },
       };
 


### PR DESCRIPTION
Removing English auto detection allows Google to default to Finnish for Varaamo's Google search results.