### PR TITLE
Moved cookie bar to be first element in the page

### DIFF
--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -55,6 +55,7 @@ export class UnconnectedAppContainer extends Component {
     const { fontSize } = this.props;
     return (
       <div className={classNames('app', getCustomizationClassName(), (fontSize))}>
+        <CookieBar />
         <SkipLink />
 
         <Helmet htmlAttributes={{ lang: this.props.currentLanguage }} title="Varaamo" />
@@ -70,7 +71,6 @@ export class UnconnectedAppContainer extends Component {
           {this.props.children}
         </main>
         <Footer />
-        <CookieBar />
       </div>
     );
   }


### PR DESCRIPTION
Cookie permissions are now the first element screen readers see when entering the site