### PR TITLE
Added min-height to resource reservation panel

### DIFF
--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -237,7 +237,7 @@ class UnconnectedResourcePage extends Component {
                     unit={unit}
                   />
 
-                  <Panel defaultExpanded header={t('ResourceInfo.reserveTitle')} role="region">
+                  <Panel defaultExpanded header={t('ResourceInfo.reserveTitle')} id="reservation-panel" role="region">
                     <Panel.Heading>
                       <Panel.Title componentClass="h2">
                         {t('ResourceCalendar.header')}

--- a/app/pages/resource/_resource-page.scss
+++ b/app/pages/resource/_resource-page.scss
@@ -197,3 +197,10 @@ $content-padding: 10px;
       }
    }
 }
+
+#reservation-panel {
+  min-height: 450px;
+  @media (min-width: $screen-md-min){
+    min-height: 680px;
+  }
+}


### PR DESCRIPTION
Min-height ensures date picker has enough space when there are no or only few timeslots