### PR TITLE
Modified which btns are shown in my reservations

### DIFF
--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -57,45 +57,50 @@ class ReservationControls extends Component {
     };
   }
 
-  renderButtons(buttons, isAdmin, isStaff, reservation) {
+  renderButtons(buttons, isAdmin, isStaff, reservation, canModify, canDelete) {
     if (!reservation.needManualConfirmation) {
       if (reservation.state === 'cancelled') {
         return null;
       }
-      return isAdmin
-        ? [buttons.edit, buttons.cancel]
-        : [buttons.edit, buttons.cancel];
+      const givenButtons = [];
+      if (canModify) {
+        givenButtons.push(buttons.edit);
+      }
+      if (canDelete) {
+        givenButtons.push(buttons.cancel);
+      }
+      return givenButtons;
     }
 
     switch (reservation.state) {
       case 'cancelled': {
         return isAdmin
-          ? [buttons.info]
-          : [buttons.info];
+          ? []
+          : [];
       }
 
       case 'confirmed': {
         if (isAdmin) {
           return isStaff
-            ? [buttons.info, buttons.cancel, buttons.edit]
-            : [buttons.info, buttons.cancel];
+            ? [buttons.cancel, buttons.edit]
+            : [buttons.cancel];
         }
-        return [buttons.info, buttons.cancel];
+        return [buttons.cancel];
       }
 
       case 'denied': {
         return isAdmin
-          ? [buttons.info]
-          : [buttons.info];
+          ? []
+          : [];
       }
 
       case 'requested': {
         if (isAdmin) {
           return isStaff
-            ? [buttons.info, buttons.confirm, buttons.deny, buttons.edit]
-            : [buttons.info, buttons.edit];
+            ? [buttons.confirm, buttons.deny, buttons.edit]
+            : [buttons.edit];
         }
-        return [buttons.info, buttons.edit, buttons.cancel];
+        return [buttons.edit, buttons.cancel];
       }
 
       default: {
@@ -107,13 +112,23 @@ class ReservationControls extends Component {
   render() {
     const { isAdmin, isStaff, reservation } = this.props;
 
+    /*
+      Reservation permissions can be used to determine what user can do.
+      For example reservations with paid products cannot be modified without
+      correct staff permissions.
+     */
+    const userPermissions = 'userPermissions' in reservation ? reservation.userPermissions : {};
+    const canModify = 'canModify' in userPermissions ? userPermissions.canModify : false;
+    const canDelete = 'canDelete' in userPermissions ? userPermissions.canDelete : false;
+
     if (!reservation || moment() > moment(reservation.end)) {
       return null;
     }
 
     return (
       <div className="buttons">
-        {this.renderButtons(this.buttons, isAdmin, isStaff, reservation)}
+        {this.buttons.info}
+        {this.renderButtons(this.buttons, isAdmin, isStaff, reservation, canModify, canDelete)}
       </div>
     );
   }

--- a/app/shared/reservation-controls/ReservationControls.spec.js
+++ b/app/shared/reservation-controls/ReservationControls.spec.js
@@ -32,19 +32,68 @@ describe('shared/reservation-controls/ReservationControls', () => {
     const isAdmin = true;
 
     describe('with regular reservation', () => {
-      const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed' });
-      const buttons = getWrapper(reservation, isAdmin).find(Button);
+      describe('without reservation user permissions', () => {
+        const userPermissions = {};
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      test('renders two buttons', () => {
-        expect(buttons.length).toBe(2);
+        test('renders one button', () => {
+          expect(buttons.length).toBe(1);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
       });
 
-      describe('the first button', () => {
-        makeButtonTests(buttons.at(0), 'edit', 'ReservationControls.edit', onEditClick);
+      describe('with reservation user permission canModify', () => {
+        const userPermissions = { canModify: true };
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+        test('renders two buttons', () => {
+          expect(buttons.length).toBe(2);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
+        describe('the second button', () => {
+          makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
+        });
       });
 
-      describe('the second button', () => {
-        makeButtonTests(buttons.at(1), 'cancel', 'ReservationControls.cancel', onCancelClick);
+      describe('with reservation user permission canDelete', () => {
+        const userPermissions = { canDelete: true };
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+        test('renders two buttons', () => {
+          expect(buttons.length).toBe(2);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
+        describe('the second button', () => {
+          makeButtonTests(buttons.at(1), 'cancel', 'ReservationControls.cancel', onCancelClick);
+        });
+      });
+
+      describe('with reservation user permissions canModify and canDelete', () => {
+        const userPermissions = { canModify: true, canDelete: true };
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+        test('renders three buttons', () => {
+          expect(buttons.length).toBe(3);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
+        describe('the second button', () => {
+          makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
+        });
+        describe('the third button', () => {
+          makeButtonTests(buttons.at(2), 'cancel', 'ReservationControls.cancel', onCancelClick);
+        });
       });
     });
 
@@ -167,19 +216,68 @@ describe('shared/reservation-controls/ReservationControls', () => {
     const isAdmin = false;
 
     describe('with regular reservation', () => {
-      const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed' });
-      const buttons = getWrapper(reservation, isAdmin).find(Button);
+      describe('without reservation user permissions', () => {
+        const userPermissions = {};
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      test('renders two buttons', () => {
-        expect(buttons.length).toBe(2);
+        test('renders one button', () => {
+          expect(buttons.length).toBe(1);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
       });
 
-      describe('the first button', () => {
-        makeButtonTests(buttons.at(0), 'edit', 'ReservationControls.edit', onEditClick);
+      describe('with reservation user permission canModify', () => {
+        const userPermissions = { canModify: true };
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+        test('renders two buttons', () => {
+          expect(buttons.length).toBe(2);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
+        describe('the second button', () => {
+          makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
+        });
       });
 
-      describe('the second button', () => {
-        makeButtonTests(buttons.at(1), 'cancel', 'ReservationControls.cancel', onCancelClick);
+      describe('with reservation user permission canDelete', () => {
+        const userPermissions = { canDelete: true };
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+        test('renders two buttons', () => {
+          expect(buttons.length).toBe(2);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
+        describe('the second button', () => {
+          makeButtonTests(buttons.at(1), 'cancel', 'ReservationControls.cancel', onCancelClick);
+        });
+      });
+
+      describe('with reservation user permissions canModify and canDelete', () => {
+        const userPermissions = { canModify: true, canDelete: true };
+        const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed', userPermissions });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+        test('renders three buttons', () => {
+          expect(buttons.length).toBe(3);
+        });
+        describe('the first button', () => {
+          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
+        });
+        describe('the second button', () => {
+          makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
+        });
+        describe('the third button', () => {
+          makeButtonTests(buttons.at(2), 'cancel', 'ReservationControls.cancel', onCancelClick);
+        });
       });
     });
 


### PR DESCRIPTION
Info button is now always shown. Reservations which don't require manual confirmation use reservation user permissions to determine whether edit and cancel buttons shown or not.