### PR TITLE
Reservation info modal updates

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -66,6 +66,7 @@
   "common.numberOfParticipantsLabel": "Number of participants",
   "common.ok": "OK",
   "common.optionsAllLabel": "All",
+  "common.orderDetailsLabel": "Order details",
   "common.payerInformationLabel": "Payer information",
   "common.previous": "Previous",
   "common.priceLabel": "Price",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -66,6 +66,7 @@
   "common.numberOfParticipantsLabel": "Osallistujamäärä",
   "common.ok": "Valmis",
   "common.optionsAllLabel": "Kaikki",
+  "common.orderDetailsLabel": "Tilaustiedot",
   "common.payerInformationLabel": "Maksajan tiedot",
   "common.previous": "Edellinen",
   "common.priceLabel": "Hinta",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -66,6 +66,7 @@
   "common.numberOfParticipantsLabel": "Antal deltagare",
   "common.ok": "OK",
   "common.optionsAllLabel": "Alla",
+  "common.orderDetailsLabel": "Orderdetaljer",
   "common.payerInformationLabel": "Betalarens information",
   "common.previous": "Föregående",
   "common.priceLabel": "Pris",

--- a/app/pages/user-reservations/UserReservationsPage.js
+++ b/app/pages/user-reservations/UserReservationsPage.js
@@ -30,7 +30,7 @@ class UnconnectedUserReservationsPage extends Component {
     }
     this.props.actions.fetchResources();
     this.props.actions.fetchUnits();
-    this.props.actions.fetchReservations({ isOwn: true });
+    this.props.actions.fetchReservations({ isOwn: true, include: 'order_detail' });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/app/pages/user-reservations/UserReservationsPage.spec.js
+++ b/app/pages/user-reservations/UserReservationsPage.spec.js
@@ -155,6 +155,7 @@ describe('pages/user-reservations/UserReservationsPage', () => {
       test('fetches only user\'s own reservations', () => {
         expect(fetchReservations.callCount).toBe(1);
         expect(fetchReservations.lastCall.args[0].isOwn).toBe(true);
+        expect(fetchReservations.lastCall.args[0].include).toBe('order_detail');
       });
     });
 
@@ -184,6 +185,7 @@ describe('pages/user-reservations/UserReservationsPage', () => {
 
       test('fetches admin\'s own reservations', () => {
         expect(fetchReservations.calls[1].args[0].isOwn).toBe(true);
+        expect(fetchReservations.calls[1].args[0].include).toBe('order_detail');
       });
     });
   });

--- a/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.js
+++ b/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import Modal from 'react-bootstrap/lib/Modal';
-import { FormattedHTMLMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -69,7 +68,6 @@ class UnconnectedReservationCancelModalContainer extends Component {
             && (
             <div>
               <p>{t('ReservationCancelModal.cancelNotAllowedInfo')}</p>
-              <p><FormattedHTMLMessage id="ReservationCancelModal.takeIntoAccount" /></p>
               <p className="responsible-contact-info">{resource.responsibleContactInfo}</p>
             </div>
             )

--- a/app/shared/modals/reservation-cancel/reservationCancelModalSelector.js
+++ b/app/shared/modals/reservation-cancel/reservationCancelModalSelector.js
@@ -8,6 +8,7 @@ import { isAdminSelector } from 'state/selectors/authSelectors';
 import { createResourceSelector } from 'state/selectors/dataSelectors';
 import modalIsOpenSelectorFactory from 'state/selectors/factories/modalIsOpenSelectorFactory';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
+import { hasOrder } from '../../../utils/reservationUtils';
 
 function reservationSelector(state) {
   return state.ui.reservations.toCancel[0] || {};
@@ -22,7 +23,9 @@ const cancelAllowedSelector = createSelector(
   isAdminSelector,
   reservationSelector,
   (isAdmin, reservation) => (
-    isAdmin || !reservation.needManualConfirmation || reservation.state !== 'confirmed'
+    isAdmin
+    || (!reservation.needManualConfirmation && !hasOrder(reservation))
+    || (reservation.state !== 'confirmed' && !hasOrder(reservation))
   )
 );
 

--- a/app/shared/modals/reservation-cancel/reservationCancelModalSelector.spec.js
+++ b/app/shared/modals/reservation-cancel/reservationCancelModalSelector.spec.js
@@ -50,6 +50,29 @@ describe('shared/modals/reservation-cancel/reservationCancelModalSelector', () =
         expect(selected.cancelAllowed).toBe(false);
       }
     );
+
+    test('returns false if user is not admin and reservation has an order', () => {
+      const reservationA = {
+        id: 'reservation-A',
+        needManualConfirmation: true,
+        state: 'confirmed',
+        order: { id: 'abc123' }
+      };
+      const reservationB = {
+        id: 'reservation-B',
+        needManualConfirmation: false,
+        state: 'requested',
+        order: { id: 'fgh456' }
+      };
+      const selectedA = getSelected({
+        'ui.reservations.toCancel': [reservationA],
+      });
+      const selectedB = getSelected({
+        'ui.reservations.toCancel': [reservationB],
+      });
+      expect(selectedA.cancelAllowed).toBe(false);
+      expect(selectedB.cancelAllowed).toBe(false);
+    });
   });
 
   describe('isCancellingReservations', () => {

--- a/app/shared/modals/reservation-info/ReservationEditForm.spec.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.spec.js
@@ -59,18 +59,6 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
         return getWrapper(props).find(Form).html();
       }
 
-      test('renders billingAddressCity', () => {
-        expect(getData()).toContain(reservation.billingAddressCity);
-      });
-
-      test('renders billingAddressStreet', () => {
-        expect(getData()).toContain(reservation.billingAddressStreet);
-      });
-
-      test('renders billingAddressZip', () => {
-        expect(getData()).toContain(reservation.billingAddressZip);
-      });
-
       describe('comments', () => {
         test('are not rendered if user is not an admin', () => {
           const props = {
@@ -153,17 +141,27 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
           reserverEmailAddress: null,
           user,
         });
+        describe('when user is staff', () => {
+          const isStaff = true;
+          test('renders reservation user name when reserverName is empty', () => {
+            expect(getData({ reservation: userReservation, isStaff })).toContain(user.displayName);
+          });
 
-        test('renders reservation user name when reserverName is empty', () => {
-          expect(getData({ reservation: userReservation })).toContain(user.displayName);
+          test('renders reservation user email when reserverEmailAddress is empty', () => {
+            expect(getData({ reservation: userReservation, isStaff })).toContain(user.email);
+          });
         });
+        describe('when user is not staff', () => {
+          const isStaff = false;
+          test('does not render reservation user name when reserverName is empty', () => {
+            expect(getData({ reservation: userReservation, isStaff }))
+              .not.toContain(user.displayName);
+          });
 
-        test(
-          'renders reservation user email when reserverEmailAddress is empty',
-          () => {
-            expect(getData({ reservation: userReservation })).toContain(user.email);
-          }
-        );
+          test('does not render reservation user email when reserverEmailAddress is empty', () => {
+            expect(getData({ reservation: userReservation, isStaff })).not.toContain(user.email);
+          });
+        });
       });
 
       describe('requires assistance', () => {
@@ -221,6 +219,52 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
         });
         test('is not rendered if reservation doesnt support it', () => {
           expect(getData()).not.toContain('common.homeMunicipality');
+        });
+      });
+
+      describe('order details', () => {
+        describe('when reservation has order with price info', () => {
+          const userReservation = Reservation.build({
+            order: {
+              orderLines: [{
+                product: {
+                  price: { amount: '3.50', period: '01:00:00', type: 'per_period' },
+                  quantity: 1,
+                  type: 'rent'
+                }
+              }],
+              price: '3.50'
+            }
+          });
+
+          test('heading is rendered', () => {
+            expect(getData({ reservation: userReservation }))
+              .toContain('common.orderDetailsLabel');
+          });
+          test('price is rendered', () => {
+            expect(getData({ reservation: userReservation }))
+              .toContain('common.priceLabel');
+          });
+          test('total price is rendered', () => {
+            expect(getData({ reservation: userReservation }))
+              .toContain('common.priceTotalLabel');
+          });
+        });
+
+        describe('when reservation does not have an order', () => {
+          const userReservation = Reservation.build({ order: null });
+          test('heading is not rendered', () => {
+            expect(getData({ reservation: userReservation }))
+              .not.toContain('common.orderDetailsLabel');
+          });
+          test('price is not rendered', () => {
+            expect(getData({ reservation: userReservation }))
+              .not.toContain('common.priceLabel');
+          });
+          test('total price is not rendered', () => {
+            expect(getData({ reservation: userReservation }))
+              .not.toContain('common.priceTotalLabel');
+          });
         });
       });
     });

--- a/app/shared/modals/reservation-info/_reservation-info-modal.scss
+++ b/app/shared/modals/reservation-info/_reservation-info-modal.scss
@@ -40,6 +40,10 @@
     .well {
       background-color: $light-gray;
     }
+
+    &-heading {
+      font-size: 1.2em;
+    }
   }
 
   .comments-form {

--- a/app/utils/__tests__/reservationUtils.spec.js
+++ b/app/utils/__tests__/reservationUtils.spec.js
@@ -13,6 +13,7 @@ import {
   getNextReservation,
   isValidPhoneNumber,
   createOrderLines,
+  hasOrder,
   hasProducts,
   createOrder,
   checkOrderPrice,
@@ -341,6 +342,18 @@ describe('Utils: reservationUtils', () => {
           expect(isValidPhoneNumber('04012312312')).toBe(true);
         });
       });
+    });
+  });
+
+  describe('hasOrder', () => {
+    test('returns true if given reservation has an order', () => {
+      const reservation = { id: 'abc123', order: { id: 'fgh456' } };
+      expect(hasOrder(reservation)).toBe(true);
+    });
+
+    test('returns false if given reservation does not have an order', () => {
+      const reservation = { id: 'abc123', order: null };
+      expect(hasOrder(reservation)).toBe(false);
     });
   });
 

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -112,6 +112,15 @@ function isValidPhoneNumber(number) {
 }
 
 /**
+ * Checks if given reservation has an order.
+ * @param {object} reservation
+ * @returns {boolean} true if reservation has order, and false if not
+ */
+function hasOrder(reservation) {
+  return 'order' in reservation && !!reservation.order;
+}
+
+/**
  * Checks if given resource has products.
  * @param {object} resource
  * @returns {boolean} true or false
@@ -205,6 +214,7 @@ export {
   getNextAvailableTime,
   getNextReservation,
   isValidPhoneNumber,
+  hasOrder,
   hasProducts,
   createOrderLines,
   createOrder,


### PR DESCRIPTION
Changes:
- Added order info: heading, price and total price
- Removed billing address row
- Updated reservation cancel "is allowed" rules to take into account whether reservation has an order or not.
- Changed reserver user info to be only shown to staff members