### PR TITLE
Changed reservation terms to handle empty objects

### DIFF
--- a/app/shared/modals/reservation-terms/ReservationTermsModal.js
+++ b/app/shared/modals/reservation-terms/ReservationTermsModal.js
@@ -9,6 +9,7 @@ import { closeResourceTermsModal, closeResourcePaymentTermsModal } from 'actions
 import { injectT } from 'i18n';
 import WrappedText from 'shared/wrapped-text';
 import reservationTermsModalSelector from './reservationTermsModalSelector';
+import { getPaymentTermsAndConditions, getTermsAndConditions } from 'utils/resourceUtils';
 
 class UnconnectedReservationTermsModal extends Component {
   render() {
@@ -21,8 +22,10 @@ class UnconnectedReservationTermsModal extends Component {
       termsType,
     } = this.props;
 
-    const { genericTerms, name } = resource;
+    const { name } = resource;
     const isPayment = termsType === 'payment';
+    const termsText = isPayment ? getPaymentTermsAndConditions(resource)
+      : getTermsAndConditions(resource);
 
     return (
       <Modal
@@ -46,7 +49,7 @@ class UnconnectedReservationTermsModal extends Component {
               <WrappedText
                 allowNamedLinks
                 openLinksInNewTab
-                text={isPayment ? resource.paymentTerms : genericTerms}
+                text={termsText}
               />
             </span>
           </div>

--- a/app/shared/modals/reservation-terms/ReservationTermsModal.spec.js
+++ b/app/shared/modals/reservation-terms/ReservationTermsModal.spec.js
@@ -91,7 +91,7 @@ describe('shared/modals/reservation-cancel/ReservationTermsModal', () => {
         expect(wrappedText.prop('openLinksInNewTab')).toBe(true);
       });
 
-      test('renders correct WrappedText when terms type is not payment', () => {
+      test('renders correct WrappedText when terms type is payment', () => {
         const resourceWithTerms = Resource.build({
           paymentTerms: 'some payment terms',
         });

--- a/app/utils/__tests__/resourceUtils.spec.js
+++ b/app/utils/__tests__/resourceUtils.spec.js
@@ -902,12 +902,20 @@ describe('Utils: resourceUtils', () => {
     });
 
     describe('when only specific terms is specified', () => {
-      const genericTerms = null;
       const specificTerms = 'specific terms';
 
-      test('returns only specific terms', () => {
-        const resource = { genericTerms, specificTerms };
-        expect(getTermsAndConditions(resource)).toBe(specificTerms);
+      describe('returns only specific terms', () => {
+        test('when generic terms is falsy', () => {
+          const genericTerms = null;
+          const resource = { genericTerms, specificTerms };
+          expect(getTermsAndConditions(resource)).toBe(specificTerms);
+        });
+
+        test('when generic terms is empty obj', () => {
+          const genericTerms = {};
+          const resource = { genericTerms, specificTerms };
+          expect(getTermsAndConditions(resource)).toBe(specificTerms);
+        });
       });
     });
 
@@ -915,20 +923,27 @@ describe('Utils: resourceUtils', () => {
       const genericTerms = 'generic terms';
       const specificTerms = null;
 
-      test('returns only specific terms', () => {
+      test('returns only generic terms', () => {
         const resource = { genericTerms, specificTerms };
         expect(getTermsAndConditions(resource)).toBe(genericTerms);
       });
     });
 
     describe('when neither specific or generic terms is specified', () => {
-      const genericTerms = null;
       const specificTerms = null;
 
-      test('returns an empty string', () => {
-        const resource = { genericTerms, specificTerms };
+      describe('returns an empty string', () => {
+        test('when generic terms is falsy', () => {
+          const genericTerms = '';
+          const resource = { genericTerms, specificTerms };
+          expect(getTermsAndConditions(resource)).toBe('');
+        });
 
-        expect(getTermsAndConditions(resource)).toBe('');
+        test('when generic terms is empty obj', () => {
+          const genericTerms = {};
+          const resource = { genericTerms, specificTerms };
+          expect(getTermsAndConditions(resource)).toBe('');
+        });
       });
     });
   });
@@ -939,9 +954,16 @@ describe('Utils: resourceUtils', () => {
       expect(getPaymentTermsAndConditions(resource)).toBe(resource.paymentTerms);
     });
 
-    test('returns empty string if given resource doesnt have payment terms', () => {
-      const resource = { };
-      expect(getPaymentTermsAndConditions(resource)).toBe('');
+    describe('returns empty string', () => {
+      test('when given resource doesnt have payment terms', () => {
+        const resource = { };
+        expect(getPaymentTermsAndConditions(resource)).toBe('');
+      });
+
+      test('when given resource has payment terms as empty obj', () => {
+        const resource = { paymentTerms: {} };
+        expect(getPaymentTermsAndConditions(resource)).toBe('');
+      });
     });
   });
 

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -251,8 +251,7 @@ function getTermsAndConditions(resource = {}) {
 }
 
 function getPaymentTermsAndConditions(resource = {}) {
-  const paymentTerms = resource.paymentTerms && !isEmpty(resource.paymentTerms) ? resource.paymentTerms : '';
-  return paymentTerms;
+  return resource.paymentTerms && !isEmpty(resource.paymentTerms) ? resource.paymentTerms : '';
 }
 
 function reservingIsRestricted(resource, date) {

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -2,6 +2,7 @@ import constants from 'constants/AppConstants';
 
 import filter from 'lodash/filter';
 import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
 import forEach from 'lodash/forEach';
 import moment from 'moment';
 import queryString from 'query-string';
@@ -240,7 +241,7 @@ function getResourcePageUrlComponents(resource, date, time) {
 }
 
 function getTermsAndConditions(resource = {}) {
-  const genericTerms = resource.genericTerms || '';
+  const genericTerms = resource.genericTerms && !isEmpty(resource.genericTerms) ? resource.genericTerms : '';
   const specificTerms = resource.specificTerms || '';
 
   if (genericTerms && specificTerms) {
@@ -250,7 +251,7 @@ function getTermsAndConditions(resource = {}) {
 }
 
 function getPaymentTermsAndConditions(resource = {}) {
-  const paymentTerms = resource.paymentTerms || '';
+  const paymentTerms = resource.paymentTerms && !isEmpty(resource.paymentTerms) ? resource.paymentTerms : '';
   return paymentTerms;
 }
 


### PR DESCRIPTION
Resource reservation terms can be empty objects which are now correctly handled by the reservation page.