### PR TITLE
Fixed a reservation updating issue

### DIFF
--- a/app/state/reducers/ui/manageReservationsPageReducer.js
+++ b/app/state/reducers/ui/manageReservationsPageReducer.js
@@ -15,6 +15,12 @@ import Immutable from 'seamless-immutable';
 export function updateResults(reservation, oldResults, reservationState) {
   const results = [...oldResults];
   const modifiedIndex = results.findIndex((result => result.id === reservation.id));
+
+  // return results as is if modified reservation was not found
+  if (modifiedIndex === -1) {
+    return results;
+  }
+
   const resource = results[modifiedIndex].resource;
 
   const updatedReservation = {


### PR DESCRIPTION
Fixed reservation updating outside of manage reservations page. Problem was caused by unhandled not found result error.