### PR TITLE
Updated staff perm check to include newer perms

### DIFF
--- a/app/pages/manage-reservations/ManageReservationsPage.js
+++ b/app/pages/manage-reservations/ManageReservationsPage.js
@@ -109,6 +109,8 @@ class ManageReservationsPage extends React.Component {
 
   handleOpenInfoModal(reservation) {
     const { actions } = this.props;
+    // fetch resource to get user permission info
+    this.handleFetchResource(reservation.resource, reservation.begin);
     actions.showReservationInfoModal(reservation);
   }
 

--- a/app/pages/manage-reservations/__tests__/ManageReservationsPage.spec.js
+++ b/app/pages/manage-reservations/__tests__/ManageReservationsPage.spec.js
@@ -247,8 +247,17 @@ describe('ManageReservationsFilters', () => {
     });
 
     describe('handleOpenInfoModal', () => {
+      const reservation = Reservation.build({ resource: 'test-id' });
+
+      test('calls handleFetchResource with correct params', () => {
+        const instance = getWrapper().instance();
+        const spy = jest.spyOn(instance, 'handleFetchResource');
+        instance.handleOpenInfoModal(reservation);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(reservation.resource, reservation.begin);
+      });
+
       test('calls showReservationInfoModal with correct params', () => {
-        const reservation = Reservation.build();
         const instance = getWrapper().instance();
         instance.handleOpenInfoModal(reservation);
         expect(defaultProps.actions.showReservationInfoModal.mock.calls.length).toBe(1);

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -2,6 +2,8 @@ import forIn from 'lodash/forIn';
 import includes from 'lodash/includes';
 import { createSelector } from 'reselect';
 
+import { isStaffForResource } from 'utils/resourceUtils';
+
 const authUserSelector = state => state.auth.user;
 const usersSelector = state => state.data.users;
 const isLoadingUserSelector = state => state.auth.isLoadingUser;
@@ -77,7 +79,7 @@ function createIsStaffSelector(resourceSelector) {
   return createSelector(
     resourceSelector,
     staffUnitsSelector,
-    (resource, staffUnits) => includes(staffUnits, resource.unit)
+    (resource, staffUnits) => includes(staffUnits, resource.unit) || isStaffForResource(resource)
   );
 }
 

--- a/app/utils/__tests__/resourceUtils.spec.js
+++ b/app/utils/__tests__/resourceUtils.spec.js
@@ -23,6 +23,7 @@ import {
   getResourcePageUrlComponents,
   getMinPeriodText,
   getEquipment,
+  isStaffForResource,
   isStrongAuthSatisfied,
 } from 'utils/resourceUtils';
 
@@ -1074,6 +1075,43 @@ describe('Utils: resourceUtils', () => {
         const resource = { userPermissions: { isAdmin: false }, reservableBefore };
         const isLimited = reservingIsRestricted(resource, date);
         expect(isLimited).toBe(true);
+      });
+    });
+  });
+
+  describe('isStaffForResource', () => {
+    describe('returns false', () => {
+      test('when given resource doesnt contain userPermissions', () => {
+        const resource = Resource.build({ userPermissions: null });
+        expect(isStaffForResource(resource)).toBe(false);
+      });
+
+      test('when none of the userPermissions admin, manager or viewer permission is true', () => {
+        const resource = Resource.build({
+          userPermissions: { isAdmin: false, isManager: false, isViewer: false }
+        });
+        expect(isStaffForResource(resource)).toBe(false);
+      });
+    });
+
+    describe('returns true', () => {
+      test('when any of the userPermissions admin, manager or viewer permission is true', () => {
+        const resourceA = Resource.build({
+          userPermissions: { isAdmin: true, isManager: false, isViewer: false }
+        });
+        const resourceB = Resource.build({
+          userPermissions: { isAdmin: false, isManager: true, isViewer: false }
+        });
+        const resourceC = Resource.build({
+          userPermissions: { isAdmin: false, isManager: false, isViewer: true }
+        });
+        const resourceD = Resource.build({
+          userPermissions: { isAdmin: true, isManager: true, isViewer: true }
+        });
+        expect(isStaffForResource(resourceA)).toBe(true);
+        expect(isStaffForResource(resourceB)).toBe(true);
+        expect(isStaffForResource(resourceC)).toBe(true);
+        expect(isStaffForResource(resourceD)).toBe(true);
       });
     });
   });

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -264,6 +264,22 @@ function reservingIsRestricted(resource, date) {
 }
 
 /**
+ * Check whether current user has any of the staff permissions:
+ * admin, manager or viewer for given resource.
+ * @param {object} resource
+ * @returns {boolean} true when user has any of the staff permissions, false if not.
+ */
+function isStaffForResource(resource) {
+  if (resource.userPermissions) {
+    const perms = resource.userPermissions;
+    if (perms.isAdmin || perms.isManager || perms.isViewer) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Checks whether strong auth requirement is satisfied with given resource and
  * strong auth status.
  * @param {object} resource
@@ -293,5 +309,6 @@ export {
   getPrice,
   reservingIsRestricted,
   getMinPeriodText,
+  isStaffForResource,
   isStrongAuthSatisfied,
 };


### PR DESCRIPTION
Changed staff permission check used by reservation info modal and reservation page to also include admin, manager and viewer permissions. Changed manage reservations page reservation info modal open handler to also fetch full resource info to get user permissions.