### PR TITLE
Disabled reservation success modal animations

### DIFF
--- a/app/shared/modals/reservation-success/ReservationSuccessModal.js
+++ b/app/shared/modals/reservation-success/ReservationSuccessModal.js
@@ -24,6 +24,7 @@ function ReservationSuccessModal({
 
   return (
     <Modal
+      animation={false}
       className="reservation-success-modal modal-city-theme"
       onHide={closeReservationSuccessModal}
       show={show}

--- a/app/shared/modals/reservation-success/ReservationSuccessModal.spec.js
+++ b/app/shared/modals/reservation-success/ReservationSuccessModal.spec.js
@@ -49,6 +49,7 @@ describe('shared/modals/reservation-success/ReservationSuccessModal', () => {
     test('renders a Modal with correct props', () => {
       const modalComponent = wrapper.find(Modal);
       expect(modalComponent.length).toBe(1);
+      expect(modalComponent.prop('animation')).toBe(false);
       expect(modalComponent.prop('className')).toBe('reservation-success-modal modal-city-theme');
       expect(modalComponent.prop('onHide')).toBe(defaultProps.closeReservationSuccessModal);
       expect(modalComponent.prop('show')).toBe(defaultProps.show);
@@ -153,6 +154,7 @@ describe('shared/modals/reservation-success/ReservationSuccessModal', () => {
     test('renders a Modal with correct props', () => {
       const modalComponent = wrapper.find(Modal);
       expect(modalComponent.length).toBe(1);
+      expect(modalComponent.prop('animation')).toBe(false);
       expect(modalComponent.prop('className')).toBe('reservation-success-modal modal-city-theme');
       expect(modalComponent.prop('onHide')).toBe(defaultProps.closeReservationSuccessModal);
       expect(modalComponent.prop('show')).toBe(defaultProps.show);


### PR DESCRIPTION
Disabling modal animations prevents them getting stuck in some instances.