### PR TITLE
siteimprove element IDs not unique fix

### DIFF
--- a/app/shared/top-navbar/TopNavbar.js
+++ b/app/shared/top-navbar/TopNavbar.js
@@ -47,7 +47,7 @@ class TopNavbar extends Component {
 
   componentDidUpdate(prevState) {
     if (!prevState.expandMobileNavbar && this.state.expandMobileNavbar) {
-      document.getElementById('contrastButton').focus();
+      document.getElementById('mobile-contrastButton').focus();
       event.preventDefault();
     }
   }
@@ -150,7 +150,7 @@ class TopNavbar extends Component {
           </Navbar.Header>
           <Navbar.Collapse id="navCollapse">
             <Nav pullRight role="list">
-              <ContrastChanger />
+              <ContrastChanger idPrefix="desktop" />
 
               <FontChanger />
               <LanguageDropdown

--- a/app/shared/top-navbar/accessibility/TopNavbarContrast.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarContrast.js
@@ -7,6 +7,7 @@ class ContrastChanger extends Component {
   static propTypes = {
     t: PropTypes.func.isRequired,
     changeContrast: PropTypes.func,
+    idPrefix: PropTypes.string,
   };
 
 
@@ -33,7 +34,9 @@ class ContrastChanger extends Component {
   }
 
   render() {
-    const { t } = this.props;
+    const { t, idPrefix } = this.props;
+    let buttonId = 'contrastButton';
+    if (idPrefix) { buttonId = `${idPrefix}-${buttonId}`; }
     return (
       <li className="navbar__contrast">
         <div className="accessibility__contrast" role="presentation">
@@ -42,7 +45,7 @@ class ContrastChanger extends Component {
             aria-label={t('Nav.Contrast.button')}
             aria-pressed={this.state.ariaState}
             className="contrast_button"
-            id="contrastButton"
+            id={buttonId}
             onClick={this.handleOnClick}
             tabIndex="0"
             type="button"

--- a/app/shared/top-navbar/accessibility/TopNavbarContrast.spec.js
+++ b/app/shared/top-navbar/accessibility/TopNavbarContrast.spec.js
@@ -61,5 +61,12 @@ describe('shared/top-navbar/accessibility/TopNavbarContrast', () => {
       expect(element.prop('tabIndex')).toBe('0');
       expect(element.prop('type')).toBe('button');
     });
+    test('has correct id based on props', () => {
+      let element = content.find('button').last();
+      expect(element.prop('id')).toBe('contrastButton');
+      content.setProps({ idPrefix: 'mobile' });
+      element = content.find('button').last();
+      expect(element.prop('id')).toBe('mobile-contrastButton');
+    });
   });
 });

--- a/app/shared/top-navbar/language-dropdown/LanguageDropdown.js
+++ b/app/shared/top-navbar/language-dropdown/LanguageDropdown.js
@@ -44,7 +44,7 @@ function LanguageDropdown(props) {
           aria-label={t('Navbar.language.active')}
           className={`${props.classNameOptional ? props.classNameOptional : 'langDrop'}`}
           href="#"
-          id="langdropdown"
+          id={`${id}-langdropdown`}
           onClick={toggleDropdown}
           ref={ref}
         >

--- a/app/shared/top-navbar/language-dropdown/LanguageDropdown.spec.js
+++ b/app/shared/top-navbar/language-dropdown/LanguageDropdown.spec.js
@@ -112,8 +112,15 @@ describe('shared/top-navbar/language-dropdown', () => {
         expect(element.prop('aria-haspopup')).toBe('true');
         expect(element.prop('aria-label')).toBe('Navbar.language.active');
         expect(element.prop('href')).toBe('#');
-        expect(element.prop('id')).toBe('langdropdown');
+        expect(element.prop('id')).toBe(`${defaults.id}-langdropdown`);
         expect(element.prop('onClick')).toBeDefined();
+      });
+      test('with correct id prop based on props', () => {
+        let element = wrapper.find('a').first();
+        expect(element.prop('id')).toBe(`${defaults.id}-langdropdown`);
+        wrapper.setProps({ id: 'mobile' });
+        element = wrapper.find('a').first();
+        expect(element.prop('id')).toBe('mobile-langdropdown');
       });
 
       test('with correct children', () => {

--- a/app/shared/top-navbar/mobile/MobileNavbar.js
+++ b/app/shared/top-navbar/mobile/MobileNavbar.js
@@ -23,7 +23,7 @@ class MobileNavbar extends React.Component {
           <Row>
             <Col sm={6} smOffset={6} xs={12}>
               <ul>
-                <ContrastChanger />
+                <ContrastChanger idPrefix="mobile" />
                 <FontChanger />
               </ul>
             </Col>


### PR DESCRIPTION
Changes:
- Added new `idPrefix` prop to ContrastChanger that is used in determining the `id` attribute of the button.
- Language dropdown button `id` now uses the `id` prop as a prefix.

This fixes the `Element IDs are not unique` accessibility issue found by siteimprove.