### PR TITLE
Fixed reservation info modal font sizing

### DIFF
--- a/app/shared/modals/_modals.scss
+++ b/app/shared/modals/_modals.scss
@@ -1,4 +1,5 @@
 @import './comment/comment-modal';
+@import './reservation-cancel/reservation-cancel-modal';
 @import './reservation-info/reservation-info-modal';
 @import './reservation-success/reservation-success-modal';
 

--- a/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.js
+++ b/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.js
@@ -27,6 +27,7 @@ class UnconnectedReservationCancelModalContainer extends Component {
     const {
       actions,
       cancelAllowed,
+      fontSize,
       isCancellingReservations,
       reservation,
       resource,
@@ -36,11 +37,12 @@ class UnconnectedReservationCancelModalContainer extends Component {
 
     return (
       <Modal
+        className={fontSize}
         onHide={actions.closeReservationCancelModal}
         show={show}
       >
         <Modal.Header closeButton closeLabel={t('ModalHeader.closeButtonText')}>
-          <Modal.Title>
+          <Modal.Title componentClass="h3">
             {cancelAllowed
               ? t('ReservationCancelModal.cancelAllowedTitle')
               : t('ReservationCancelModal.cancelNotAllowedTitle')
@@ -77,6 +79,7 @@ class UnconnectedReservationCancelModalContainer extends Component {
         <Modal.Footer>
           <Button
             bsStyle="default"
+            className={fontSize}
             onClick={actions.closeReservationCancelModal}
           >
             {cancelAllowed
@@ -87,6 +90,7 @@ class UnconnectedReservationCancelModalContainer extends Component {
           {cancelAllowed && (
             <Button
               bsStyle="danger"
+              className={fontSize}
               disabled={isCancellingReservations}
               onClick={this.handleCancel}
             >
@@ -105,6 +109,7 @@ class UnconnectedReservationCancelModalContainer extends Component {
 UnconnectedReservationCancelModalContainer.propTypes = {
   actions: PropTypes.object.isRequired,
   cancelAllowed: PropTypes.bool.isRequired,
+  fontSize: PropTypes.string.isRequired,
   isCancellingReservations: PropTypes.bool.isRequired,
   reservation: PropTypes.object.isRequired,
   resource: PropTypes.object.isRequired,

--- a/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.spec.js
+++ b/app/shared/modals/reservation-cancel/ReservationCancelModalContainer.spec.js
@@ -20,6 +20,7 @@ describe('shared/modals/reservation-cancel/ReservationCancelModalContainer', () 
       deleteReservation: () => null,
     },
     cancelAllowed: false,
+    fontSize: 'test-large',
     isCancellingReservations: false,
     reservation,
     resource,
@@ -34,6 +35,9 @@ describe('shared/modals/reservation-cancel/ReservationCancelModalContainer', () 
     test('renders a Modal component', () => {
       const modalComponent = getWrapper().find(Modal);
       expect(modalComponent.length).toBe(1);
+      expect(modalComponent.prop('className')).toBe(defaultProps.fontSize);
+      expect(modalComponent.prop('onHide')).toBe(defaultProps.actions.closeReservationCancelModal);
+      expect(modalComponent.prop('show')).toBe(defaultProps.show);
     });
 
     describe('Modal header', () => {
@@ -61,6 +65,7 @@ describe('shared/modals/reservation-cancel/ReservationCancelModalContainer', () 
           const modalTitle = getModalHeaderWrapper({ cancelAllowed: false }).find(Modal.Title);
           expect(modalTitle.length).toBe(1);
           expect(modalTitle.prop('children')).toBe('ReservationCancelModal.cancelNotAllowedTitle');
+          expect(modalTitle.prop('componentClass')).toBe('h3');
         });
       });
     });
@@ -117,10 +122,15 @@ describe('shared/modals/reservation-cancel/ReservationCancelModalContainer', () 
         const buttons = getFooterButtonsWrapper({ cancelAllowed });
 
         test('renders cancel button', () => {
+          expect(buttons.at(0).prop('bsStyle')).toBe('default');
+          expect(buttons.at(0).prop('className')).toBe(defaultProps.fontSize);
           expect(buttons.at(0).props().children).toBe('ReservationCancelModal.cancelAllowedCancel');
         });
 
         test('renders confirm button', () => {
+          expect(buttons.at(1).prop('bsStyle')).toBe('danger');
+          expect(buttons.at(1).prop('className')).toBe(defaultProps.fontSize);
+          expect(buttons.at(1).prop('disabled')).toBe(defaultProps.isCancellingReservations);
           expect(buttons.at(1).props().children).toBe('ReservationCancelModal.cancelAllowedConfirm');
         });
       });

--- a/app/shared/modals/reservation-cancel/_reservation-cancel-modal.scss
+++ b/app/shared/modals/reservation-cancel/_reservation-cancel-modal.scss
@@ -1,0 +1,5 @@
+.modal-footer {
+  .btn {
+    margin-top: 8px;
+  }
+}

--- a/app/shared/modals/reservation-cancel/reservationCancelModalSelector.js
+++ b/app/shared/modals/reservation-cancel/reservationCancelModalSelector.js
@@ -8,6 +8,7 @@ import { isAdminSelector } from 'state/selectors/authSelectors';
 import { createResourceSelector } from 'state/selectors/dataSelectors';
 import modalIsOpenSelectorFactory from 'state/selectors/factories/modalIsOpenSelectorFactory';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
+import { fontSizeSelector } from 'state/selectors/accessibilitySelectors';
 import { hasOrder } from '../../../utils/reservationUtils';
 
 function reservationSelector(state) {
@@ -31,6 +32,7 @@ const cancelAllowedSelector = createSelector(
 
 const reservationCancelModalSelector = createStructuredSelector({
   cancelAllowed: cancelAllowedSelector,
+  fontSize: fontSizeSelector,
   isCancellingReservations: requestIsActiveSelectorFactory(
     ActionTypes.API.RESERVATION_DELETE_REQUEST
   ),

--- a/app/shared/modals/reservation-cancel/reservationCancelModalSelector.spec.js
+++ b/app/shared/modals/reservation-cancel/reservationCancelModalSelector.spec.js
@@ -1,4 +1,3 @@
-
 import ActionTypes from 'constants/ActionTypes';
 import ModalTypes from 'constants/ModalTypes';
 
@@ -73,6 +72,10 @@ describe('shared/modals/reservation-cancel/reservationCancelModalSelector', () =
       expect(selectedA.cancelAllowed).toBe(false);
       expect(selectedB.cancelAllowed).toBe(false);
     });
+  });
+
+  test('returns fontSize', () => {
+    expect(getSelected().fontSize).toBeDefined();
   });
 
   describe('isCancellingReservations', () => {

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -25,6 +25,7 @@ class UnconnectedReservationEditForm extends Component {
     super(props);
     this.renderAddressRow = this.renderAddressRow.bind(this);
     this.renderEditableInfoRow = this.renderEditableInfoRow.bind(this);
+    this.renderHeading = this.renderHeading.bind(this);
     this.renderInfoRow = this.renderInfoRow.bind(this);
     this.renderReservationTime = this.renderReservationTime.bind(this);
   }
@@ -53,9 +54,10 @@ class UnconnectedReservationEditForm extends Component {
   }
 
   renderHeading(label) {
+    const { isLargerFontSize } = this.props;
     return (
       <Row>
-        <Col sm={3}>
+        <Col sm={isLargerFontSize ? 12 : 3}>
           <h4 className="reservation-edit-form-heading">{label}</h4>
         </Col>
       </Row>
@@ -63,13 +65,14 @@ class UnconnectedReservationEditForm extends Component {
   }
 
   renderInfoRow(label, value) {
+    const { isLargerFontSize } = this.props;
     if (!value && value !== '') return null;
     return (
       <FormGroup>
-        <Col sm={3}>
+        <Col sm={isLargerFontSize ? 12 : 3}>
           <ControlLabel>{label}</ControlLabel>
         </Col>
-        <Col sm={9}>
+        <Col sm={isLargerFontSize ? 12 : 9}>
           <FormControl.Static>{value}</FormControl.Static>
         </Col>
       </FormGroup>
@@ -238,6 +241,7 @@ UnconnectedReservationEditForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isEditing: PropTypes.bool.isRequired,
+  isLargerFontSize: PropTypes.bool.isRequired,
   isSaving: PropTypes.bool.isRequired,
   isStaff: PropTypes.bool.isRequired,
   onCancelEditClick: PropTypes.func.isRequired,

--- a/app/shared/modals/reservation-info/ReservationEditForm.spec.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.spec.js
@@ -39,6 +39,7 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
     handleSubmit: () => null,
     isAdmin: true,
     isEditing: false,
+    isLargerFontSize: false,
     isSaving: false,
     isStaff: false,
     onCancelEditClick: () => null,

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -6,6 +6,7 @@ import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import FormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Modal from 'react-bootstrap/lib/Modal';
+import classNames from 'classnames';
 
 import { injectT } from 'i18n';
 import ReservationCancelModal from 'shared/modals/reservation-cancel';
@@ -39,10 +40,13 @@ class ReservationInfoModal extends Component {
 
   render() {
     const {
+      contrast,
       currentLanguage,
+      fontSize,
       hideReservationInfoModal,
       isAdmin,
       isEditing,
+      isLargerFontSize,
       isSaving,
       isStaff,
       onCancelClick,
@@ -65,12 +69,14 @@ class ReservationInfoModal extends Component {
 
     return (
       <Modal
-        className="reservation-info-modal"
+        className={classNames('reservation-info-modal', fontSize, contrast)}
         onHide={hideReservationInfoModal}
         show={show}
       >
         <Modal.Header closeButton closeLabel={t('ModalHeader.closeButtonText')}>
-          <Modal.Title>{t('ReservationInfoModal.title')}</Modal.Title>
+          <Modal.Title componentClass="h3">
+            {t('ReservationInfoModal.title')}
+          </Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
@@ -84,6 +90,7 @@ class ReservationInfoModal extends Component {
                 initialValues={reservation}
                 isAdmin={isAdmin}
                 isEditing={isEditing}
+                isLargerFontSize={isLargerFontSize}
                 isSaving={isSaving}
                 isStaff={isStaff}
                 onCancelEditClick={onCancelEditClick}
@@ -130,6 +137,7 @@ class ReservationInfoModal extends Component {
         <Modal.Footer>
           <Button
             bsStyle="default"
+            className={fontSize}
             onClick={hideReservationInfoModal}
           >
             {t('common.back')}
@@ -137,6 +145,7 @@ class ReservationInfoModal extends Component {
           {isStaff && reservationIsEditable && reservation.state === 'requested' && (
             <Button
               bsStyle="danger"
+              className={fontSize}
               disabled={disabled}
               onClick={onDenyClick}
             >
@@ -146,6 +155,7 @@ class ReservationInfoModal extends Component {
           {isStaff && reservationIsEditable && reservation.state === 'requested' && (
             <Button
               bsStyle="success"
+              className={fontSize}
               disabled={disabled}
               onClick={onConfirmClick}
             >
@@ -155,6 +165,7 @@ class ReservationInfoModal extends Component {
           {showCancelButton && (
             <Button
               bsStyle="danger"
+              className={fontSize}
               disabled={disabled}
               onClick={onCancelClick}
             >
@@ -169,10 +180,13 @@ class ReservationInfoModal extends Component {
 }
 
 ReservationInfoModal.propTypes = {
+  contrast: PropTypes.string.isRequired,
   currentLanguage: PropTypes.string.isRequired,
+  fontSize: PropTypes.string.isRequired,
   hideReservationInfoModal: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isEditing: PropTypes.bool.isRequired,
+  isLargerFontSize: PropTypes.bool.isRequired,
   isSaving: PropTypes.bool.isRequired,
   isStaff: PropTypes.bool.isRequired,
   onCancelClick: PropTypes.func.isRequired,

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -4,6 +4,7 @@ import FormControl from 'react-bootstrap/lib/FormControl';
 import Modal from 'react-bootstrap/lib/Modal';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
+import classNames from 'classnames';
 
 import ReservationStateLabel from 'shared/reservation-state-label';
 import Reservation from 'utils/fixtures/Reservation';
@@ -31,10 +32,13 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
     resource: resource.id,
   });
   const defaultProps = {
+    contrast: 'test-high',
     currentLanguage: 'fi',
+    fontSize: 'test-small',
     hideReservationInfoModal: () => null,
     isAdmin: false,
     isEditing: false,
+    isLargerFontSize: false,
     isSaving: false,
     isStaff: false,
     onCancelClick: () => null,
@@ -57,8 +61,11 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
   describe('render', () => {
     test('renders a Modal component', () => {
       const modalComponent = getWrapper().find(Modal);
-
       expect(modalComponent.length).toBe(1);
+      expect(modalComponent.prop('className'))
+        .toBe(classNames('reservation-info-modal', defaultProps.fontSize, defaultProps.contrast));
+      expect(modalComponent.prop('onHide')).toBe(defaultProps.hideReservationInfoModal);
+      expect(modalComponent.prop('show')).toBe(defaultProps.show);
     });
 
     describe('Modal header', () => {
@@ -76,6 +83,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
       test('renders a ModalTitle with correct title', () => {
         const modalTitle = getWrapper().find(Modal.Title);
         expect(modalTitle.length).toBe(1);
+        expect(modalTitle.prop('componentClass')).toBe('h3');
         expect(modalTitle.prop('children')).toBe('ReservationInfoModal.title');
       });
     });
@@ -102,6 +110,7 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
         expect(editForm.prop('initialValues')).toBe(defaultProps.reservation);
         expect(editForm.prop('isAdmin')).toBe(defaultProps.isAdmin);
         expect(editForm.prop('isEditing')).toBe(defaultProps.isEditing);
+        expect(editForm.prop('isLargerFontSize')).toBe(defaultProps.isLargerFontSize);
         expect(editForm.prop('isSaving')).toBe(defaultProps.isSaving);
         expect(editForm.prop('isStaff')).toBe(defaultProps.isStaff);
         expect(editForm.prop('onCancelEditClick')).toBe(defaultProps.onCancelEditClick);
@@ -176,6 +185,21 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
     });
 
     describe('Footer', () => {
+      describe('all buttons', () => {
+        test('have correct className', () => {
+          const props = {
+            isStaff: true,
+            reservationIsEditable: true,
+            reservation: { ...reservation, state: 'requested' },
+          };
+          const buttons = getWrapper(props).find(Modal.Footer).find(Button);
+          expect(buttons).toHaveLength(4);
+          buttons.forEach((button) => {
+            expect(button.prop('className')).toBe(defaultProps.fontSize);
+          });
+        });
+      });
+
       describe('back button', () => {
         function getBackButton(props) {
           const hideReservationInfoModal = () => null;

--- a/app/shared/modals/reservation-info/_reservation-info-modal.scss
+++ b/app/shared/modals/reservation-info/_reservation-info-modal.scss
@@ -9,6 +9,19 @@
     text-align: right;
     font-size: 2.4rem;
     margin-bottom: 10px;
+
+    .label-success {
+      background-color: #008540;
+    }
+    .label-danger {
+      background-color: #ab1204;
+    }
+    .label-primary {
+      background-color: #c15801;
+    }
+    .label-default {
+      background-color: #37475e;
+    }
   }
 
   .reservation-edit-form {
@@ -16,6 +29,10 @@
     margin-left: -10px;
     margin-right: -10px;
     margin-bottom: 15px;
+    @media (min-width: $screen-sm-min) {
+      margin-left: 0;
+      margin-right: 0;
+    }
 
     &.editing {
       background-color: $gray-lighter;
@@ -60,9 +77,20 @@
   }
 
   #reservation-order-info {
+    margin-top: 24px;
+
     hr {
       border-style: solid;
       border-width: 1px;
+    }
+  }
+}
+
+.high-contrast {
+  .reservation-edit-form {
+    .well {
+      background-color: white;
+      border: 1px solid $black;
     }
   }
 }

--- a/app/shared/modals/reservation-info/reservationInfoModalSelector.js
+++ b/app/shared/modals/reservation-info/reservationInfoModalSelector.js
@@ -7,6 +7,7 @@ import { createIsStaffSelector, isAdminSelector } from 'state/selectors/authSele
 import { createResourceSelector } from 'state/selectors/dataSelectors';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
 import { currentLanguageSelector } from 'state/selectors/translationSelectors';
+import { contrastSelector, fontSizeSelector, isLargerFontSizeSelector } from 'state/selectors/accessibilitySelectors';
 
 function reservationSelector(state) {
   return state.ui.reservationInfoModal.reservation || {};
@@ -28,9 +29,12 @@ const resourceIdSelector = createSelector(
 const resourceSelector = createResourceSelector(resourceIdSelector);
 
 const reservationInfoModalSelector = createStructuredSelector({
+  contrast: contrastSelector,
   currentLanguage: currentLanguageSelector,
+  fontSize: fontSizeSelector,
   isAdmin: isAdminSelector,
   isEditing: state => state.ui.reservationInfoModal.isEditing,
+  isLargerFontSize: isLargerFontSizeSelector,
   isSaving: requestIsActiveSelectorFactory(ActionTypes.API.RESERVATION_PUT_REQUEST),
   isStaff: createIsStaffSelector(resourceSelector),
   reservation: reservationSelector,

--- a/app/shared/modals/reservation-info/reservationInfoModalSelector.spec.js
+++ b/app/shared/modals/reservation-info/reservationInfoModalSelector.spec.js
@@ -11,8 +11,16 @@ describe('shared/modals/reservation-info/reservationInfoModalSelector', () => {
     return reservationInfoModalSelector(state);
   }
 
+  test('returns contrast', () => {
+    expect(getSelected().contrast).toBeDefined();
+  });
+
   test('returns currentLanguage', () => {
     expect(getSelected().currentLanguage).toBeDefined();
+  });
+
+  test('returns fontSize', () => {
+    expect(getSelected().fontSize).toBeDefined();
   });
 
   test('returns isAdmin', () => {
@@ -33,6 +41,10 @@ describe('shared/modals/reservation-info/reservationInfoModalSelector', () => {
       });
       expect(selected.isEditing).toBe(false);
     });
+  });
+
+  test('returns isLargerFontSize', () => {
+    expect(getSelected().isLargerFontSize).toBeDefined();
   });
 
   describe('isSaving', () => {

--- a/app/state/selectors/accessibilitySelectors.js
+++ b/app/state/selectors/accessibilitySelectors.js
@@ -6,7 +6,17 @@ function isLargerFontSizeSelector(state) {
 
 const contrastSelector = state => (state.ui.accessibility.isHighContrast ? 'high-contrast' : '');
 
+/**
+ * Returns currently selected fontsize as a css className
+ * @param {object} state
+ * @returns {string} className for different font size settings
+ */
+function fontSizeSelector(state) {
+  return state.ui.accessibility.fontSize;
+}
+
 export {
   isLargerFontSizeSelector,
-  contrastSelector
+  contrastSelector,
+  fontSizeSelector,
 };

--- a/app/state/selectors/accessibilitySelectors.spec.js
+++ b/app/state/selectors/accessibilitySelectors.spec.js
@@ -1,7 +1,7 @@
 import APP from 'constants/AppConstants';
 
 import { getState } from 'utils/testUtils';
-import { isLargerFontSizeSelector, contrastSelector } from './accessibilitySelectors';
+import { isLargerFontSizeSelector, contrastSelector, fontSizeSelector } from './accessibilitySelectors';
 
 describe('state/selectors/accessibilitySelectors', () => {
   describe('isLargerFontSizeSelector', () => {
@@ -22,6 +22,20 @@ describe('state/selectors/accessibilitySelectors', () => {
 
     test('returns true if font size is large', () => {
       expect(getSelected(APP.FONT_SIZES.LARGE)).toBe(true);
+    });
+  });
+
+  describe('fontSizeSelector', () => {
+    function getSelected(fontSize = APP.FONT_SIZES.SMALL) {
+      const state = getState({
+        'ui.accessibility': { fontSize }
+      });
+      return fontSizeSelector(state);
+    }
+    test('returns current font size css className', () => {
+      expect(getSelected()).toBe(APP.FONT_SIZES.SMALL);
+      expect(getSelected(APP.FONT_SIZES.MEDIUM)).toBe(APP.FONT_SIZES.MEDIUM);
+      expect(getSelected(APP.FONT_SIZES.LARGE)).toBe(APP.FONT_SIZES.LARGE);
     });
   });
 


### PR DESCRIPTION
Changes:
- modal font size is now defined by user's selected font size
- modal info fields are now stacked when there is not enough space for the fields to be on the same row
- small improvements to modal accessibility and styles