### PR TITLE
Fixed resource page unit web address rendering

### DIFF
--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -58,12 +58,12 @@ function ResourceInfo({
                 </a>
               </span>
               )}
-              {unit && unit.wwwUrl && (
-              <span className="app-ResourceInfo__www">
-                <a href={unit.wwwUrl} rel="noopener noreferrer" target="_blank">
-                  {t('ResourceInfo.webSiteLink')}
-                </a>
-              </span>
+              {(unit && unit.wwwUrl && typeof unit.wwwUrl === 'string') && (
+                <span className="app-ResourceInfo__www">
+                  <a href={unit.wwwUrl} rel="noopener noreferrer" target="_blank">
+                    {t('ResourceInfo.webSiteLink')}
+                  </a>
+                </span>
               )}
             </Col>
           </Row>

--- a/app/pages/resource/resource-info/ResourceInfo.spec.js
+++ b/app/pages/resource/resource-info/ResourceInfo.spec.js
@@ -140,6 +140,30 @@ describe('pages/resource/resource-info/ResourceInfo', () => {
     expect(link.text()).toBe('ResourceInfo.webSiteLink');
   });
 
+  describe('does not render web address', () => {
+    test('when address is not a string', () => {
+      const unit = Unit.build({
+        wwwUrl: {},
+      });
+      const link = getWrapper({ unit })
+        .find('.app-ResourceInfo__www')
+        .find('a');
+
+      expect(link).toHaveLength(0);
+    });
+
+    test('when address is falsy', () => {
+      const unit = Unit.build({
+        wwwUrl: '',
+      });
+      const link = getWrapper({ unit })
+        .find('.app-ResourceInfo__www')
+        .find('a');
+
+      expect(link).toHaveLength(0);
+    });
+  });
+
   test('renders service map link', () => {
     const unit = Unit.build({
       id: 'abc',


### PR DESCRIPTION
When unit web address does not exist or is not a string, address is no longer incorrectly rendered on the resource page