### PR TITLE
Improved shown resource page min and max periods

### DIFF
--- a/app/pages/reservation/reservation-products/ReservationProductsUtils.js
+++ b/app/pages/reservation/reservation-products/ReservationProductsUtils.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 export const PRODUCT_TYPES = {
   MANDATORY: 'rent',
   EXTRA: 'extra'
@@ -112,21 +110,4 @@ export function compareTaxPercentages(taxA, taxB) {
  */
 export function getSortedTaxPercentages(taxPercentages) {
   return taxPercentages.sort(compareTaxPercentages);
-}
-
-/**
- * Formats given period into hours and/or minutes
- * @param {string} pricePeriod e.g. 1:30:00
- * @returns {string} e.g. '1h 30min', '2h' or '45min'
- */
-export function getPrettifiedPeriodUnits(pricePeriod) {
-  const duration = moment.duration(pricePeriod);
-  const hours = duration.hours();
-  const minutes = duration.minutes();
-
-  const hoursText = hours > 0 ? `${hours}h` : '';
-  const minutesText = minutes > 0 ? `${minutes}min` : '';
-  const spacer = hoursText && minutesText ? ' ' : '';
-
-  return `${hoursText}${spacer}${minutesText}`;
 }

--- a/app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js
+++ b/app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 import injectT from '../../../../i18n/injectT';
 import QuantityInput from './QuantityInput';
-import { getPrettifiedPeriodUnits, getRoundedVat } from '../ReservationProductsUtils';
+import { getRoundedVat } from '../ReservationProductsUtils';
+import { getPrettifiedPeriodUnits } from 'utils/timeUtils';
 import { getLocalizedFieldValue } from 'utils/languageUtils';
 
 function ExtraProductTableRow({

--- a/app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import injectT from '../../../../i18n/injectT';
-import { getPrettifiedPeriodUnits, getRoundedVat } from '../ReservationProductsUtils';
+import { getRoundedVat } from '../ReservationProductsUtils';
+import { getPrettifiedPeriodUnits } from 'utils/timeUtils';
 import { getLocalizedFieldValue } from 'utils/languageUtils';
 
 function MandatoryProductTableRow({ currentLanguage, orderLine, t }) {

--- a/app/pages/reservation/reservation-products/tests/ReservationProductsUtils.spec.js
+++ b/app/pages/reservation/reservation-products/tests/ReservationProductsUtils.spec.js
@@ -2,7 +2,7 @@ import OrderLine from 'utils/fixtures/OrderLine';
 import Product from 'utils/fixtures/Product';
 import {
   calculateTax, compareTaxPercentages, getOrderTaxTotals, getProductsOfType,
-  getRoundedVat, getSortedTaxPercentages, roundPriceToTwoDecimals, getPrettifiedPeriodUnits
+  getRoundedVat, getSortedTaxPercentages, roundPriceToTwoDecimals
 } from '../ReservationProductsUtils';
 
 describe('reservation-products/ReservationProductsUtils', () => {
@@ -174,15 +174,6 @@ describe('reservation-products/ReservationProductsUtils', () => {
     test('returns given tax percentages from smallert to largest', () => {
       expect(getSortedTaxPercentages([taxA, taxB, taxC, taxD]))
         .toStrictEqual([taxD, taxA, taxC, taxB]);
-    });
-  });
-
-  describe('getPrettifiedPeriodUnits', () => {
-    test('returns correct string', () => {
-      expect(getPrettifiedPeriodUnits('1:30:00')).toBe('1h 30min');
-      expect(getPrettifiedPeriodUnits('2:00:00')).toBe('2h');
-      expect(getPrettifiedPeriodUnits('0:25:00')).toBe('25min');
-      expect(getPrettifiedPeriodUnits('0:00:00')).toBe('');
     });
   });
 });

--- a/app/pages/resource/resource-header/ResourceHeader.js
+++ b/app/pages/resource/resource-header/ResourceHeader.js
@@ -99,10 +99,12 @@ function ResourceHeader({
               />
               <span className="app-ResourceHeader__info-label">{peopleCapacityText}</span>
             </div>
-            <div className="app-ResourceHeader__info">
-              <img alt={t('ResourceHeader.maxTime')} className="app-ResourceHeader__info-icon" src={iconClock} />
-              <span className="app-ResourceHeader__info-label">{`Max ${maxPeriodText}`}</span>
-            </div>
+            {maxPeriodText && (
+              <div className="app-ResourceHeader__info" id="resource-header-max-period">
+                <img alt={t('ResourceHeader.maxTime')} className="app-ResourceHeader__info-icon" src={iconClock} />
+                <span className="app-ResourceHeader__info-label">{`Max ${maxPeriodText}`}</span>
+              </div>
+            )}
             <div className="app-ResourceHeader__info">
               <img alt={t('ResourceHeader.price')} className="app-ResourceHeader__info-icon" src={iconTicket} />
               <span className="app-ResourceHeader__info-label">{priceText}</span>

--- a/app/pages/resource/resource-header/ResourceHeader.spec.js
+++ b/app/pages/resource/resource-header/ResourceHeader.spec.js
@@ -8,10 +8,11 @@ import Resource from 'utils/fixtures/Resource';
 import Unit from 'utils/fixtures/Unit';
 import { shallowWithIntl } from 'utils/testUtils';
 import ResourceHeader from './ResourceHeader';
+import { getMaxPeriodText } from 'utils/resourceUtils';
 
 describe('pages/resource/resource-header/ResourceHeader', () => {
   const unit = Unit.build({ name: 'Test Unit' });
-  const resource = Resource.build({ unit: Unit.id });
+  const resource = Resource.build({ unit: Unit.id, maxPeriod: '01:00:00' });
   const defaultProps = {
     onBackClick: () => null,
     onMapClick: () => null,
@@ -76,14 +77,30 @@ describe('pages/resource/resource-header/ResourceHeader', () => {
       });
     });
 
-    describe('MaxTime info', () => {
-      test('renders type image with correct props', () => {
-        const infos = getWrapper().find('.app-ResourceHeader__info');
-        const images = infos.find('img');
+    describe('Max time info', () => {
+      const t = value => value;
 
-        expect(images).toHaveLength(5);
+      describe('when max time exists', () => {
+        const resourceA = Resource.build({ maxPeriod: '01:30:00' });
+        const timeInfo = getWrapper({ resource: resourceA }).find('#resource-header-max-period');
+        test('renders type image with correct props', () => {
+          const image = timeInfo.find('img');
+          expect(image.prop('alt')).toBe('ResourceHeader.maxTime');
+        });
 
-        expect(images.at(2).prop('alt')).toBe('ResourceHeader.maxTime');
+        test('renders type span text', () => {
+          const span = timeInfo.find('.app-ResourceHeader__info-label');
+          expect(span.text()).toBe(`Max ${getMaxPeriodText(t, resourceA)}`);
+        });
+      });
+
+      test('is not rendered when max time does not exist', () => {
+        const resourceA = Resource.build({ maxPeriod: '' });
+        const resourceB = Resource.build({ maxPeriod: '00:00:00' });
+        const timeInfoA = getWrapper({ resource: resourceA }).find('#resource-header-max-period');
+        const timeInfoB = getWrapper({ resource: resourceB }).find('#resource-header-max-period');
+        expect(timeInfoA).toHaveLength(0);
+        expect(timeInfoB).toHaveLength(0);
       });
     });
 
@@ -102,7 +119,7 @@ describe('pages/resource/resource-header/ResourceHeader', () => {
     describe('Unit info', () => {
       function createProps(resourceProps) {
         return {
-          resource: Immutable(Resource.build(resourceProps)),
+          resource: Immutable(Resource.build({ maxPeriod: '01:00:00', ...resourceProps })),
         };
       }
 

--- a/app/utils/__tests__/resourceUtils.spec.js
+++ b/app/utils/__tests__/resourceUtils.spec.js
@@ -26,6 +26,7 @@ import {
   isStaffForResource,
   isStrongAuthSatisfied,
 } from 'utils/resourceUtils';
+import { getPrettifiedPeriodUnits } from '../timeUtils';
 
 describe('Utils: resourceUtils', () => {
   describe('hasMaxReservations', () => {
@@ -656,15 +657,11 @@ describe('Utils: resourceUtils', () => {
       expect(result).toBe('days');
     });
 
-    test('returns max period as hours', () => {
-      const t = simple.stub().returnWith('hours');
+    test('returns correct time string when period is less than 1 day ', () => {
+      const t = value => value;
       const resource = { maxPeriod: '02:00:00' };
-      const result = getMaxPeriodText(t, resource);
-
-      expect(t.callCount).toBe(1);
-      expect(t.lastCall.args[0]).toEqual('ResourceHeader.maxPeriodHours');
-      expect(t.lastCall.args[1]).toEqual({ hours: 2 });
-      expect(result).toBe('hours');
+      const expectedResult = getPrettifiedPeriodUnits(resource.maxPeriod);
+      expect(getMaxPeriodText(t, resource)).toBe(expectedResult);
     });
   });
 
@@ -680,15 +677,11 @@ describe('Utils: resourceUtils', () => {
       expect(result).toBe('days');
     });
 
-    test('returns min period as hours', () => {
-      const t = simple.stub().returnWith('hours');
-      const resource = { minPeriod: '02:00:00' };
-      const result = getMinPeriodText(t, resource);
-
-      expect(t.callCount).toBe(1);
-      expect(t.lastCall.args[0]).toEqual('ResourceHeader.minPeriodHours');
-      expect(t.lastCall.args[1]).toEqual({ hours: 2 });
-      expect(result).toBe('hours');
+    test('returns correct time string when period is less than 1 day ', () => {
+      const t = value => value;
+      const resource = { maxPeriod: '02:40:00' };
+      const expectedResult = getPrettifiedPeriodUnits(resource.maxPeriod);
+      expect(getMaxPeriodText(t, resource)).toBe(expectedResult);
     });
   });
 

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -20,6 +20,7 @@ import {
   isPastDate,
   isValidDateString,
   padLeft,
+  getPrettifiedPeriodUnits,
   prettifyHours,
   periodToMinute,
   getEndTimeSlotWithMinPeriod
@@ -692,6 +693,15 @@ describe('Utils: timeUtils', () => {
       expect(isValidDateString(dateOne)).toBe(false);
       expect(isValidDateString(dateTwo)).toBe(false);
       expect(isValidDateString(dateThree)).toBe(false);
+    });
+  });
+
+  describe('getPrettifiedPeriodUnits', () => {
+    test('returns correct string', () => {
+      expect(getPrettifiedPeriodUnits('1:30:00')).toBe('1h 30min');
+      expect(getPrettifiedPeriodUnits('2:00:00')).toBe('2h');
+      expect(getPrettifiedPeriodUnits('0:25:00')).toBe('25min');
+      expect(getPrettifiedPeriodUnits('0:00:00')).toBe('');
     });
   });
 

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -8,6 +8,7 @@ import moment from 'moment';
 import queryString from 'query-string';
 
 import { getCurrentReservation, getNextAvailableTime } from 'utils/reservationUtils';
+import { getPrettifiedPeriodUnits } from './timeUtils';
 
 function hasMaxReservations(resource) {
   let isMaxReservations = false;
@@ -176,21 +177,19 @@ function getHumanizedPeriod(period) {
 }
 
 function getMaxPeriodText(t, { maxPeriod }) {
-  const hours = moment.duration(maxPeriod).asHours();
   const days = parseInt(moment.duration(maxPeriod).asDays(), 10);
   if (days > 0) {
     return t('ResourceHeader.maxPeriodDays', { days });
   }
-  return t('ResourceHeader.maxPeriodHours', { hours });
+  return getPrettifiedPeriodUnits(maxPeriod);
 }
 
 function getMinPeriodText(t, { minPeriod }) {
-  const hours = moment.duration(minPeriod).asHours();
   const days = parseInt(moment.duration(minPeriod).asDays(), 10);
   if (days > 0) {
     return t('ResourceHeader.minPeriodDays', { days });
   }
-  return t('ResourceHeader.minPeriodHours', { hours });
+  return getPrettifiedPeriodUnits(minPeriod);
 }
 
 function getOpeningHours(resource, selectedDate) {

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -232,6 +232,23 @@ function isValidDateString(dateString) {
   return false;
 }
 
+/**
+ * Formats given period into hours and/or minutes
+ * @param {string} period e.g. 1:30:00
+ * @returns {string} e.g. '1h 30min', '2h' or '45min'
+ */
+function getPrettifiedPeriodUnits(period) {
+  const duration = moment.duration(period);
+  const hours = duration.hours();
+  const minutes = duration.minutes();
+
+  const hoursText = hours > 0 ? `${hours}h` : '';
+  const minutesText = minutes > 0 ? `${minutes}min` : '';
+  const spacer = hoursText && minutesText ? ' ' : '';
+
+  return `${hoursText}${spacer}${minutesText}`;
+}
+
 function prettifyHours(hours, showMinutes = false) {
   if (showMinutes && hours < 0.5) {
     const minutes = moment.duration(hours, 'hours').minutes();
@@ -296,6 +313,7 @@ export {
   getDuration,
   getDurationHours,
   getEndTimeString,
+  getPrettifiedPeriodUnits,
   getStartTimeString,
   getTimeSlots,
   isPastDate,


### PR DESCRIPTION
Changes:
- min and max periods support both hours and minutes instead of only hours
- resource page header max period info in not rendered when max period does not exist