### PR TITLE
Improved reservation products mobile view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 node_modules
 npm-debug.log
 yarn-error.log
+/.idea

--- a/app/pages/reservation/reservation-products/MobileProduct.js
+++ b/app/pages/reservation/reservation-products/MobileProduct.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import injectT from '../../../i18n/injectT';
+import QuantityInput from './extra-products/QuantityInput';
+import { getPrettifiedPeriodUnits } from '../../../utils/timeUtils';
+import { getRoundedVat, PRODUCT_TYPES } from './ReservationProductsUtils';
+import { getLocalizedFieldValue } from '../../../utils/languageUtils';
+
+// Order prop type that is used in this file.
+const ORDER_TYPE = {
+  product: PropTypes.shape({
+    amount: PropTypes.string,
+    max_quantity: PropTypes.number,
+    name: PropTypes.object,
+    id: PropTypes.string,
+    price: PropTypes.shape({
+      amount: PropTypes.string,
+      period: PropTypes.string,
+      type: PropTypes.string,
+      tax_percentage: PropTypes.string,
+    }),
+    type: PropTypes.string,
+  }),
+  price: PropTypes.string,
+  quantity: PropTypes.number,
+};
+
+/**
+ * Returns correct elements for mandatory product.
+ * @param {Object} props
+ * @param {Object} props.order
+ * @param {*} props.t
+ * @returns {JSX.Element}
+ */
+function MandatoryProduct({ order, t }) {
+  const totalPrice = order.price;
+  const {
+    type, period, amount: basePrice, tax_percentage: vat
+  } = order.product.price;
+
+  const vatText = t('ReservationProducts.price.includesVat', { vat: getRoundedVat(vat) });
+  return (
+    <React.Fragment>
+      <p>{`${t('ReservationProducts.table.heading.price')}: ${basePrice} €${type !== 'fixed' ? ` / ${getPrettifiedPeriodUnits(period)}` : ''}`}</p>
+      <p>{`${t('ReservationProducts.table.heading.total')}: ${totalPrice} € ${vatText}`}</p>
+    </React.Fragment>
+  );
+}
+MandatoryProduct.propTypes = {
+  order: PropTypes.shape(ORDER_TYPE),
+  t: PropTypes.func,
+};
+
+/**
+ * Returns correct elements for extra product.
+ * @param {Object} props
+ * @param {Object} props.order
+ * @param {*} props.t
+ * @param {function} props.handleChange
+ * @returns {JSX.Element}
+ */
+function ExtraProduct({
+  order, t, handleChange
+}) {
+  const { amount: unitPrice, tax_percentage: vat } = order.product.price;
+  const { quantity, price: totalPrice } = order;
+  const maxQuantity = order.product.max_quantity;
+  const vatText = t('ReservationProducts.price.includesVat', { vat: getRoundedVat(vat) });
+  return (
+    <React.Fragment>
+      <p>
+        {`${t('ReservationProducts.table.heading.unitPrice')}: ${unitPrice} €`}
+      </p>
+      <div className="extra-mobile-quantity-input">
+        <QuantityInput
+          handleAdd={() => handleChange(quantity + 1, order)}
+          handleReduce={() => handleChange(quantity - 1, order)}
+          maxQuantity={maxQuantity}
+          mobile
+          quantity={quantity}
+        />
+      </div>
+      <p className="extra-mobile-total">
+        {`${t('ReservationProducts.table.heading.total')}: ${totalPrice} € ${vatText}`}
+      </p>
+    </React.Fragment>
+  );
+}
+ExtraProduct.propTypes = {
+  order: PropTypes.shape(ORDER_TYPE),
+  t: PropTypes.func,
+  handleChange: PropTypes.func,
+};
+
+/**
+ * Returns li element with content according to product.type.
+ * @param {Object} props
+ * @param {Object} props.order - Object that contains the product etc.
+ * @param {*} props.t - Used to get language specific texts.
+ * @param {function} props.handleChange - Handles quantity changes.
+ * @param {string} props.currentLanguage - The current language.
+ * @returns {JSX.Element}
+ */
+function MobileProduct({
+  order, t, handleChange, currentLanguage
+}) {
+  const { id, name, type } = order.product;
+  return (
+    <li key={id}>
+      <div>
+        <p>
+          {`${getLocalizedFieldValue(name, currentLanguage, true)}`}
+        </p>
+        {type === PRODUCT_TYPES.MANDATORY && MandatoryProduct({ order, t })}
+        {type === PRODUCT_TYPES.EXTRA && ExtraProduct({ order, t, handleChange })}
+      </div>
+    </li>
+  );
+}
+
+MobileProduct.propTypes = {
+  order: PropTypes.shape(ORDER_TYPE),
+  t: PropTypes.func,
+  handleChange: PropTypes.func,
+  currentLanguage: PropTypes.string,
+};
+
+export default injectT(MobileProduct);

--- a/app/pages/reservation/reservation-products/ReservationProducts.js
+++ b/app/pages/reservation/reservation-products/ReservationProducts.js
@@ -11,12 +11,15 @@ import MandatoryProducts from './mandatory-products/MandatoryProducts';
 import ProductsSummary from './ProductsSummary';
 import ExtraProducts from './extra-products/ExtraProducts';
 import ReservationDetails from '../reservation-details/ReservationDetails';
+import { getProductsOfType, PRODUCT_TYPES } from './ReservationProductsUtils';
 
 function ReservationProducts({
   changeProductQuantity, currentLanguage, isEditing, isStaff, onBack, onCancel, onConfirm,
   onStaffSkipChange, order, resource, selectedTime, skipMandatoryProducts, t, unit
 }) {
   const orderLines = order.order_lines || [];
+  const mandatoryOrders = getProductsOfType(orderLines, PRODUCT_TYPES.MANDATORY);
+  const extraOrders = getProductsOfType(orderLines, PRODUCT_TYPES.EXTRA);
 
   return (
     <div className="app-ReservationProducts">
@@ -29,13 +32,13 @@ function ReservationProducts({
                 currentLanguage={currentLanguage}
                 isStaff={isStaff}
                 onStaffSkipChange={onStaffSkipChange}
-                orderLines={orderLines}
+                orderLines={mandatoryOrders}
                 skipProducts={skipMandatoryProducts}
               />
               <ExtraProducts
                 changeProductQuantity={changeProductQuantity}
                 currentLanguage={currentLanguage}
-                orderLines={orderLines}
+                orderLines={extraOrders}
               />
               <ProductsSummary order={order} />
             </Loader>

--- a/app/pages/reservation/reservation-products/_reservation-products.scss
+++ b/app/pages/reservation/reservation-products/_reservation-products.scss
@@ -32,9 +32,72 @@
     white-space: nowrap;
   }
 
+  .mandatory-mobile-list, .extra-mobile-list {
+    @media (max-width: $screen-xs-max) {
+      display: block;
+    }
+    display: none;
+    >ul {
+      list-style: none;
+      padding: 0;
+    }
+    li {
+      border-top: 1px solid #525a65;
+      >div {
+        display: flex;
+        flex-direction: column;
+        text-align: center;
+        p:first-of-type {
+          margin-top: 0.5em;
+        }
+        p:first-of-type, p:last-of-type {
+          font-weight: bold;
+        }
+      }
+    }
+    li:last-of-type {
+      border-bottom: 2px solid #525a65;
+    }
+    li:first-of-type {
+      border-top: 2px solid #525a65;
+    }
+    p {
+      margin: 0 0 0.5em;
+    }
+    .extra-mobile-quantity-input {
+      display: flex;
+      justify-content: center;
+      >span {
+        padding: 5px 0;
+      }
+      button {
+        height: 2.25em;
+        width: 2.25em;
+      }
+    }
+    .extra-mobile-total {
+      margin-top: 1em;
+      font-weight: bold;
+    }
+  }
+
+  .mandatory-products {
+    table {
+      @media (max-width: $screen-xs-max) {
+        display: none;
+      }
+    }
+
+  }
   .extra-products {
     .form-group {
       margin-bottom: 0;
+    }
+
+    .table-responsive {
+      @media (max-width: $screen-xs-max) {
+        display: none;
+      }
     }
 
     .form-control {

--- a/app/pages/reservation/reservation-products/extra-products/ExtraProducts.js
+++ b/app/pages/reservation/reservation-products/extra-products/ExtraProducts.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
 
 import injectT from '../../../../i18n/injectT';
-import { getProductsOfType, PRODUCT_TYPES } from '../ReservationProductsUtils';
+import { PRODUCT_TYPES } from '../ReservationProductsUtils';
 import ExtraProductTableRow from './ExtraProductTableRow';
+import MobileProduct from '../MobileProduct';
 
 
 function ExtraProducts({
@@ -15,15 +16,26 @@ function ExtraProducts({
     changeProductQuantity(orderLine.product, newQuantity, PRODUCT_TYPES.EXTRA);
   };
 
-  const extraProducts = getProductsOfType(orderLines, PRODUCT_TYPES.EXTRA)
-    .map(orderLine => (
+  const extraProducts = [];
+  const mobileProducts = orderLines.reduce((acc, order) => {
+    acc.push(
+      <MobileProduct
+        currentLanguage={currentLanguage}
+        handleChange={handleQuantityChange}
+        key={order.product.id}
+        order={order}
+      />
+    );
+    extraProducts.push(
       <ExtraProductTableRow
         currentLanguage={currentLanguage}
         handleQuantityChange={handleQuantityChange}
-        key={orderLine.product.id}
-        orderLine={orderLine}
+        key={order.product.id}
+        orderLine={order}
       />
-    ));
+    );
+    return acc;
+  }, []);
 
   return (
     <React.Fragment>
@@ -43,6 +55,13 @@ function ExtraProducts({
               {extraProducts}
             </tbody>
           </Table>
+        </div>
+      ) : null}
+      {mobileProducts.length > 0 ? (
+        <div className="extra-mobile-list">
+          <ul>
+            {mobileProducts}
+          </ul>
         </div>
       ) : null}
     </React.Fragment>

--- a/app/pages/reservation/reservation-products/extra-products/QuantityInput.js
+++ b/app/pages/reservation/reservation-products/extra-products/QuantityInput.js
@@ -5,8 +5,9 @@ import { Glyphicon } from 'react-bootstrap';
 import injectT from '../../../../i18n/injectT';
 
 function QuantityInput({
-  handleAdd, handleReduce, quantity, maxQuantity, minQuantity, t
+  handleAdd, handleReduce, quantity, maxQuantity, minQuantity, t, mobileProduct
 }) {
+  const textValue = mobileProduct ? `${t('ReservationProducts.table.heading.quantity')}: ${quantity}` : quantity;
   return (
     <React.Fragment>
       <button
@@ -18,7 +19,7 @@ function QuantityInput({
       >
         <Glyphicon aria-hidden="true" glyph="minus" />
       </button>
-      <span aria-live="polite" role="status">{quantity}</span>
+      <span aria-live="polite" role="status">{textValue}</span>
       <button
         aria-label={t('ReservationProducts.button.addOne')}
         className="quantity-button plus"
@@ -35,6 +36,7 @@ function QuantityInput({
 QuantityInput.defaultProps = {
   maxQuantity: 0,
   minQuantity: 0,
+  mobileProduct: false,
 };
 
 QuantityInput.propTypes = {
@@ -42,6 +44,7 @@ QuantityInput.propTypes = {
   handleReduce: PropTypes.func.isRequired,
   maxQuantity: PropTypes.number,
   minQuantity: PropTypes.number,
+  mobileProduct: PropTypes.bool,
   quantity: PropTypes.number.isRequired,
   t: PropTypes.func.isRequired,
 };

--- a/app/pages/reservation/reservation-products/extra-products/tests/ExtraProductTableRow.spec.js
+++ b/app/pages/reservation/reservation-products/extra-products/tests/ExtraProductTableRow.spec.js
@@ -4,7 +4,7 @@ import { shallowWithIntl } from 'utils/testUtils';
 import { getLocalizedFieldValue } from 'utils/languageUtils';
 import ExtraProductTableRow from '../ExtraProductTableRow';
 import QuantityInput from '../QuantityInput';
-import { getPrettifiedPeriodUnits } from '../../ReservationProductsUtils';
+import { getPrettifiedPeriodUnits } from 'utils/timeUtils';
 import Product from 'utils/fixtures/Product';
 import OrderLine from 'utils/fixtures/OrderLine';
 

--- a/app/pages/reservation/reservation-products/extra-products/tests/ExtraProducts.spec.js
+++ b/app/pages/reservation/reservation-products/extra-products/tests/ExtraProducts.spec.js
@@ -6,12 +6,16 @@ import OrderLine from 'utils/fixtures/OrderLine';
 import Product from 'utils/fixtures/Product';
 import ExtraProducts from '../ExtraProducts';
 import ExtraProductTableRow from '../ExtraProductTableRow';
+import MobileProduct from '../../MobileProduct';
 
 describe('reservation-products/extra-products/ExtraProducts', () => {
   const defaultProps = {
     currentLanguage: 'fi',
     changeProductQuantity: () => {},
-    orderLines: [OrderLine.build({ product: Product.build() })]
+    orderLines: [
+      OrderLine.build({ product: Product.build() }),
+      OrderLine.build({ product: Product.build() })
+    ]
   };
 
   function getWrapper(extraProps) {
@@ -86,10 +90,35 @@ describe('reservation-products/extra-products/ExtraProducts', () => {
 
     test('ExtraProductTableRow', () => {
       const extraProductTableRow = getWrapper().find(ExtraProductTableRow);
-      expect(extraProductTableRow).toHaveLength(1);
-      expect(extraProductTableRow.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
-      expect(extraProductTableRow.prop('handleQuantityChange')).toBeDefined();
-      expect(extraProductTableRow.prop('orderLine')).toBe(defaultProps.orderLines[0]);
+      expect(extraProductTableRow).toHaveLength(2);
+      extraProductTableRow.forEach((element, index) => {
+        expect(element.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
+        expect(element.prop('handleQuantityChange')).toBeDefined();
+        expect(element.prop('orderLine')).toEqual(defaultProps.orderLines[index]);
+      });
+    });
+    describe('MobileProducts', () => {
+      test('container div exists', () => {
+        const element = getWrapper().find('div.extra-mobile-list');
+        expect(element).toHaveLength(1);
+      });
+
+      test('ul element exists', () => {
+        const element = getWrapper().find('ul');
+        expect(element).toHaveLength(1);
+        // 1 child per product so in this case 2.
+        expect(element.children()).toHaveLength(2);
+      });
+
+      test('MobileProduct for each product', () => {
+        const elements = getWrapper().find(MobileProduct);
+        expect(elements).toHaveLength(2);
+        elements.forEach((element, index) => {
+          expect(element.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
+          expect(element.prop('handleChange')).toBeDefined();
+          expect(element.prop('order')).toEqual(defaultProps.orderLines[index]);
+        });
+      });
     });
   });
 });

--- a/app/pages/reservation/reservation-products/extra-products/tests/QuantityInput.spec.js
+++ b/app/pages/reservation/reservation-products/extra-products/tests/QuantityInput.spec.js
@@ -11,6 +11,7 @@ describe('reservation-products/extra-products/QuantityInput', () => {
     maxQuantity: 10,
     minQuantity: 0,
     quantity: 2,
+    mobileProduct: false,
   };
 
   function getWrapper(extraProps) {
@@ -52,12 +53,18 @@ describe('reservation-products/extra-products/QuantityInput', () => {
       expect(glyph.prop('glyph')).toBe('plus');
     });
 
-    test('quantity span', () => {
+    test('quantity span default', () => {
       const span = getWrapper().find('span');
       expect(span).toHaveLength(1);
       expect(span.prop('aria-live')).toBe('polite');
       expect(span.prop('role')).toBe('status');
       expect(span.text()).toBe(defaultProps.quantity.toString());
+    });
+
+    test('quantity span with correct text when mobileProduct is true', () => {
+      const span = getWrapper({ mobileProduct: true }).find('span');
+      expect(span).toHaveLength(1);
+      expect(span.text()).toBe(`ReservationProducts.table.heading.quantity: ${defaultProps.quantity}`);
     });
   });
 });

--- a/app/pages/reservation/reservation-products/mandatory-products/MandatoryProducts.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/MandatoryProducts.js
@@ -4,19 +4,29 @@ import { Checkbox, Table, Well } from 'react-bootstrap';
 
 import injectT from '../../../../i18n/injectT';
 import MandatoryProductTableRow from './MandatoryProductTableRow';
-import { getProductsOfType, PRODUCT_TYPES } from '../ReservationProductsUtils';
+import MobileProduct from '../MobileProduct';
 
 function MandatoryProducts({
   currentLanguage, isStaff, onStaffSkipChange, orderLines, skipProducts, t
 }) {
-  const mandatoryProducts = getProductsOfType(orderLines, PRODUCT_TYPES.MANDATORY)
-    .map(orderLine => (
+  const mandatoryProducts = [];
+  const mobileProducts = orderLines.reduce((acc, order) => {
+    acc.push(
+      <MobileProduct
+        currentLanguage={currentLanguage}
+        key={order.product.id}
+        order={order}
+      />
+    );
+    mandatoryProducts.push(
       <MandatoryProductTableRow
         currentLanguage={currentLanguage}
-        key={orderLine.product.id}
-        orderLine={orderLine}
+        key={order.product.id}
+        orderLine={order}
       />
-    ));
+    );
+    return acc;
+  }, []);
 
   return (
     <React.Fragment>
@@ -45,6 +55,13 @@ function MandatoryProducts({
               {mandatoryProducts}
             </tbody>
           </Table>
+          {mobileProducts.length > 0 ? (
+            <div className="mandatory-mobile-list">
+              <ul>
+                {mobileProducts}
+              </ul>
+            </div>
+          ) : null}
         </div>
       ) : null}
     </React.Fragment>

--- a/app/pages/reservation/reservation-products/mandatory-products/tests/MandatoryProductTableRow.spec.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/tests/MandatoryProductTableRow.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { shallowWithIntl } from 'utils/testUtils';
 import { getLocalizedFieldValue } from 'utils/languageUtils';
-import { getPrettifiedPeriodUnits } from '../../ReservationProductsUtils';
+import { getPrettifiedPeriodUnits } from 'utils/timeUtils';
 import MandatoryProductTableRow from '../MandatoryProductTableRow';
 import OrderLine from 'utils/fixtures/OrderLine';
 import Product from 'utils/fixtures/Product';

--- a/app/pages/reservation/reservation-products/mandatory-products/tests/MandatoryProducts.spec.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/tests/MandatoryProducts.spec.js
@@ -6,14 +6,18 @@ import OrderLine from 'utils/fixtures/OrderLine';
 import Product from 'utils/fixtures/Product';
 import MandatoryProducts from '../MandatoryProducts';
 import MandatoryProductTableRow from '../MandatoryProductTableRow';
+import MobileProduct from '../../MobileProduct';
 
-describe('reservation-products/extra-products/ExtraProducts', () => {
+describe('reservation-products/mandatory-products/MandatoryProducts', () => {
   const defaultProps = {
     currentLanguage: 'fi',
     isStaff: false,
     onStaffSkipChange: () => {},
     skipProducts: false,
-    orderLines: [OrderLine.build({ product: Product.build({ type: 'rent' }) })]
+    orderLines: [
+      OrderLine.build({ product: Product.build({ type: 'rent' }) }),
+      OrderLine.build({ product: Product.build({ type: 'rent' }) })
+    ]
   };
 
   function getWrapper(extraProps) {
@@ -110,9 +114,34 @@ describe('reservation-products/extra-products/ExtraProducts', () => {
 
     test('MandatoryProductTableRow', () => {
       const mandatoryProductTableRow = getWrapper().find(MandatoryProductTableRow);
-      expect(mandatoryProductTableRow).toHaveLength(1);
-      expect(mandatoryProductTableRow.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
-      expect(mandatoryProductTableRow.prop('orderLine')).toBe(defaultProps.orderLines[0]);
+      expect(mandatoryProductTableRow).toHaveLength(2);
+      mandatoryProductTableRow.forEach((element, index) => {
+        expect(element.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
+        expect(element.prop('orderLine')).toEqual(defaultProps.orderLines[index]);
+      });
+    });
+
+    describe('MobileProducts', () => {
+      test('container div exists', () => {
+        const element = getWrapper().find('div.mandatory-mobile-list');
+        expect(element).toHaveLength(1);
+      });
+
+      test('ul element exists', () => {
+        const element = getWrapper().find('ul');
+        expect(element).toHaveLength(1);
+        // 1 child per product so in this case 2.
+        expect(element.children()).toHaveLength(2);
+      });
+
+      test('MobileProduct for each product', () => {
+        const elements = getWrapper().find(MobileProduct);
+        expect(elements).toHaveLength(2);
+        elements.forEach((element, index) => {
+          expect(element.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
+          expect(element.prop('order')).toEqual(defaultProps.orderLines[index]);
+        });
+      });
     });
   });
 });

--- a/app/pages/reservation/reservation-products/tests/MobileProduct.spec.js
+++ b/app/pages/reservation/reservation-products/tests/MobileProduct.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { shallowWithIntl } from '../../../../utils/testUtils';
-import MobileProduct, { ExtraProduct, MandatoryProduct } from '../MobileProduct';
+import MobileProduct from '../MobileProduct';
 import OrderLine from 'utils/fixtures/OrderLine';
 import Product from 'utils/fixtures/Product';
 import { getPrettifiedPeriodUnits } from '../../../../utils/timeUtils';

--- a/app/pages/reservation/reservation-products/tests/MobileProduct.spec.js
+++ b/app/pages/reservation/reservation-products/tests/MobileProduct.spec.js
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import { shallowWithIntl } from '../../../../utils/testUtils';
+import MobileProduct, { ExtraProduct, MandatoryProduct } from '../MobileProduct';
+import OrderLine from 'utils/fixtures/OrderLine';
+import Product from 'utils/fixtures/Product';
+import { getPrettifiedPeriodUnits } from '../../../../utils/timeUtils';
+import QuantityInput from '../extra-products/QuantityInput';
+
+
+describe('reservation-products/MobileProduct', () => {
+  const defaultProps = {
+    order: {},
+    handleChange: jest.fn(),
+    currentLanguage: 'fi',
+  };
+  function getWrapper(props) {
+    return shallowWithIntl(<MobileProduct {...defaultProps} {...props} />);
+  }
+  describe('MobileProduct', () => {
+    test('when order.product is mandatory and product.price type is fixed', () => {
+      const rentProduct = Product.build({
+        type: 'rent',
+        price: {
+          type: 'fixed', tax_percentage: '24.00', amount: '8.00'
+        }
+      });
+      const wrapper = getWrapper(
+        {
+          order: OrderLine.build({
+            product: rentProduct,
+            price: '8.00',
+            quantity: 1
+          })
+        }
+      );
+      const expectedValues = [
+        rentProduct.name[defaultProps.currentLanguage],
+        `ReservationProducts.table.heading.price: ${rentProduct.price.amount} €`,
+        `ReservationProducts.table.heading.total: ${rentProduct.price.amount} € ReservationProducts.price.includesVat`,
+      ];
+      expect(wrapper.find('p')).toHaveLength(3);
+      wrapper.find('p').forEach((element, index) => {
+        expect(element.text()).toEqual(expectedValues[index]);
+      });
+    });
+
+    test('when order.product is mandatory and product.price type is per_period', () => {
+      // This is a 2.5h reservation.
+      // order.quantity * order.product.price.period = 2.5h
+      // order.quantity * order.product.amount = order.price
+      const rentProduct = Product.build({
+        type: 'rent',
+        price: {
+          type: 'per_period', tax_percentage: '24.00', amount: '10.00', period: '00:30:00'
+        }
+      });
+      const orderPrice = '50.00';
+      // eslint-disable-next-line max-len
+      const orderQuantity = Number.parseInt(orderPrice, 10) / Number.parseInt(rentProduct.price.amount, 10);
+
+      const wrapper = getWrapper(
+        {
+          order: OrderLine.build({
+            product: rentProduct,
+            price: orderPrice,
+            quantity: orderQuantity,
+          })
+        }
+      );
+      const expectedValues = [
+        rentProduct.name[defaultProps.currentLanguage],
+        `ReservationProducts.table.heading.price: ${rentProduct.price.amount} € / ${getPrettifiedPeriodUnits(rentProduct.price.period)}`,
+        `ReservationProducts.table.heading.total: ${orderPrice} € ReservationProducts.price.includesVat`,
+      ];
+      expect(wrapper.find('p')).toHaveLength(3);
+      wrapper.find('p').forEach((element, index) => {
+        expect(element.text()).toEqual(expectedValues[index]);
+      });
+    });
+
+    test('when order.product is extra', () => {
+      const extraProduct = Product.build({
+        type: 'extra',
+        price: {
+          type: 'fixed', tax_percentage: '20.00', amount: '15.00'
+        },
+        max_quantity: 10,
+      });
+      const orderPrice = '45.00';
+      // eslint-disable-next-line max-len
+      const orderQuantity = Number.parseInt(orderPrice, 10) / Number.parseInt(extraProduct.price.amount, 10);
+
+      const wrapper = getWrapper(
+        {
+          order: OrderLine.build({
+            product: extraProduct,
+            price: orderPrice,
+            quantity: orderQuantity
+          })
+        }
+      );
+      const expectedValues = [
+        extraProduct.name[defaultProps.currentLanguage],
+        `ReservationProducts.table.heading.unitPrice: ${extraProduct.price.amount} €`,
+        `ReservationProducts.table.heading.total: ${orderPrice} € ReservationProducts.price.includesVat`,
+      ];
+      expect(wrapper.find('p')).toHaveLength(3);
+      wrapper.find('p').forEach((element, index) => {
+        expect(element.text()).toEqual(expectedValues[index]);
+      });
+
+      expect(wrapper.find('div.extra-mobile-quantity-input')).toHaveLength(1);
+      expect(wrapper.find(QuantityInput)).toHaveLength(1);
+      const quantityElement = wrapper.find(QuantityInput);
+      expect(quantityElement.prop('handleAdd')).toBeDefined();
+      expect(quantityElement.prop('handleReduce')).toBeDefined();
+      expect(quantityElement.prop('maxQuantity')).toEqual(extraProduct.max_quantity);
+      expect(quantityElement.prop('quantity')).toEqual(orderQuantity);
+    });
+  });
+});

--- a/app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js
+++ b/app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js
@@ -17,7 +17,31 @@ import ReservationDetails from '../../reservation-details/ReservationDetails';
 
 describe('reservation-products/ProductsSummary', () => {
   const resource = Immutable(Resource.build());
-
+  const rentProduct = Product.build({
+    type: 'rent',
+    price: {
+      type: 'fixed', tax_percentage: '24.00', amount: '8.00'
+    }
+  });
+  const extraProductOne = Product.build({
+    type: 'extra',
+    price: {
+      type: 'fixed', tax_percentage: '20.00', amount: '15.00'
+    },
+    max_quantity: 10,
+  });
+  const extraProductTwo = Product.build({
+    type: 'extra',
+    price: {
+      type: 'fixed', tax_percentage: '0.00', amount: '55.00'
+    },
+    max_quantity: 1,
+  });
+  const orderLines = [
+    OrderLine.build({ product: rentProduct, quantity: 1, price: '8.00' }),
+    OrderLine.build({ product: extraProductOne, quantity: 3, price: '45.00' }),
+    OrderLine.build({ product: extraProductTwo, quantity: 1, price: '55.00' }),
+  ];
   const defaultProps = {
     changeProductQuantity: () => {},
     currentLanguage: 'fi',
@@ -30,7 +54,7 @@ describe('reservation-products/ProductsSummary', () => {
     order: {
       begin: '2021-09-24T11:00:00+03:00',
       end: '2021-09-24T11:30:00+03:00',
-      order_lines: [OrderLine.build({ product: Product.build(), quantity: 1 })],
+      order_lines: orderLines,
       price: '5.00'
     },
     resource,
@@ -97,7 +121,7 @@ describe('reservation-products/ProductsSummary', () => {
         expect(mandatoryProducts.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
         expect(mandatoryProducts.prop('isStaff')).toBe(defaultProps.isStaff);
         expect(mandatoryProducts.prop('onStaffSkipChange')).toBe(defaultProps.onStaffSkipChange);
-        expect(mandatoryProducts.prop('orderLines')).toBe(defaultProps.order.order_lines);
+        expect(mandatoryProducts.prop('orderLines')).toEqual([orderLines[0]]);
         expect(mandatoryProducts.prop('skipProducts')).toBe(defaultProps.skipMandatoryProducts);
       });
 
@@ -106,7 +130,7 @@ describe('reservation-products/ProductsSummary', () => {
         expect(extraProducts).toHaveLength(1);
         expect(extraProducts.prop('changeProductQuantity')).toBe(defaultProps.changeProductQuantity);
         expect(extraProducts.prop('currentLanguage')).toBe(defaultProps.currentLanguage);
-        expect(extraProducts.prop('orderLines')).toBe(defaultProps.order.order_lines);
+        expect(extraProducts.prop('orderLines')).toEqual([orderLines[1], orderLines[2]]);
       });
 
       test('ProductsSummary', () => {


### PR DESCRIPTION
Changes:
- Added `MobileProduct` component that is used to display products for mobile/smaller screens. The component calls `MandatoryProduct` or `ExtraProduct` to get product type specific content.
- Added `MandatoryProduct` function that returns the correct elements for products that are mandatory.
- Added `ExtraProduct` function that returns the correct elements for products that are extra(not mandatory).
- Modified `QuantityInput` to take a `mobileProduct` boolean parameter that determines if the text value that's displayed between the buttons contains additional text(for mobile) or not. The default value for the parameter is `false`.
- Modified `MandatoryProducts` and `ExtraProducts` components to render the new `MobileProduct` list for each product. The visibility of the two different product listings is done with scss.
- Modified `ReservationProducts` so that the type specific order lines are mapped to variables that are then passed to `MandatoryProducts` and `ExtraProducts`.
- Added tests for `MobileProduct`, `MandatoryProduct` and `ExtraProduct`.
- Added new tests to `QuantityInput`, `ExtraProducts`, `MandatoryProducts` and `ReservationProducts`.
