### PR TITLE
Fixed reservation page getting stuck in info phase

### DIFF
--- a/app/pages/manage-reservations/ManageReservationsPage.js
+++ b/app/pages/manage-reservations/ManageReservationsPage.js
@@ -17,6 +17,7 @@ import Pagination from '../../shared/pagination/Pagination';
 import { getFiltersFromUrl, getSearchFromFilters } from '../../utils/searchUtils';
 import { getEditReservationUrl } from 'utils/reservationUtils';
 import {
+  clearReservations,
   selectReservationToEdit,
   showReservationInfoModal,
   openReservationCancelModal,
@@ -124,6 +125,8 @@ class ManageReservationsPage extends React.Component {
     const normalizedReservation = Object.assign(
       {}, reservation, { resource: reservation.resource.id }
     );
+    // clear old selected reservations before selecting new reservation to edit
+    actions.clearReservations();
 
     // fetch resource before changing page to make sure reservation page has
     // all needed info to function
@@ -256,6 +259,7 @@ export const UnwrappedManageReservationsPage = injectT(ManageReservationsPage);
 
 const mapDispatchToProps = (dispatch) => {
   const actionCreators = {
+    clearReservations,
     editReservation: selectReservationToEdit,
     fetchUnits,
     fetchReservations,

--- a/app/pages/manage-reservations/__tests__/ManageReservationsPage.spec.js
+++ b/app/pages/manage-reservations/__tests__/ManageReservationsPage.spec.js
@@ -22,6 +22,7 @@ import PageResultsText from '../PageResultsText';
 describe('ManageReservationsFilters', () => {
   const defaultProps = {
     actions: {
+      clearReservations: jest.fn(),
       editReservation: jest.fn(),
       fetchUnits: jest.fn(),
       fetchReservations: jest.fn(),
@@ -268,6 +269,11 @@ describe('ManageReservationsFilters', () => {
       const normalizedReservation = Object.assign(
         {}, reservation, { resource: reservation.resource.id }
       );
+      test('calls clearReservations', () => {
+        const instance = getWrapper().instance();
+        instance.handleEditClick(reservation);
+        expect(defaultProps.actions.clearReservations.mock.calls.length).toBe(1);
+      });
 
       test('calls handleFetchResource with correct params', () => {
         const instance = getWrapper().instance();


### PR DESCRIPTION
Changed manage reservations page to clear old selected reservations before selecting new reservation to edit. Old selections caused reservation page to not handle phase change correctly