### PR TITLE
Fixed randomly failing time comparison test

### DIFF
--- a/app/pages/resource/ResourcePage.spec.js
+++ b/app/pages/resource/ResourcePage.spec.js
@@ -350,6 +350,9 @@ describe('pages/resource/ResourcePage', () => {
 
       test('returns false when the day is today', () => {
         const today = new Date();
+        // to avoid problems with comparing different "now" variables,
+        // manually set this "now"/today to be the last moment in today
+        today.setHours(23, 59, 59);
         const isDisabled = instance.disableDays(today.toISOString());
         expect(isDisabled).toBe(false);
       });


### PR DESCRIPTION
The failing test compared two different "now" variables which randomly were different and caused a failing test.