### PR TITLE
Changed user reservations page staff perm check

### DIFF
--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.js
@@ -1,4 +1,3 @@
-import includes from 'lodash/includes';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Loader from 'react-loader';
@@ -18,7 +17,6 @@ class UnconnectedReservationListContainer extends Component {
     const {
       isAdmin,
       resources,
-      staffUnits,
       units,
       paymentUrlData,
     } = this.props;
@@ -28,7 +26,6 @@ class UnconnectedReservationListContainer extends Component {
     return (
       <ReservationListItem
         isAdmin={isAdmin}
-        isStaff={includes(staffUnits, resource.unit)}
         key={reservation.url}
         paymentUrlData={paymentUrlData}
         reservation={reservation}
@@ -70,7 +67,6 @@ UnconnectedReservationListContainer.propTypes = {
   loading: PropTypes.bool.isRequired,
   reservations: PropTypes.array.isRequired,
   resources: PropTypes.object.isRequired,
-  staffUnits: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
   units: PropTypes.object.isRequired,
   paymentUrlData: PropTypes.object,

--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.spec.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.spec.js
@@ -17,7 +17,6 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
       loading: false,
       reservations: [],
       resources: {},
-      staffUnits: [],
       units: {},
     };
     return shallowWithIntl(<ReservationListContainer {...defaults} {...props} />);
@@ -55,12 +54,11 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
         expect(reservationListItems).toHaveLength(props.reservations.length);
       });
 
-      test('passes isAdmin, isStaff and reservation', () => {
+      test('passes isAdmin and reservation', () => {
         const reservationListItems = getWithReservationsWrapper().find(ReservationListItem);
         reservationListItems.forEach((reservationListItem, index) => {
           const actualProps = reservationListItem.props();
           expect(actualProps.isAdmin).toBe(props.isAdmin);
-          expect(actualProps.isStaff).toBe(false);
           expect(actualProps.reservation).toEqual(props.reservations[index]);
           expect(reservationListItems.at(0).prop('resource')).toEqual(resource);
           expect(reservationListItems.at(1).prop('resource')).toEqual({});

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -23,7 +23,7 @@ class ReservationListItem extends Component {
 
   render() {
     const {
-      isAdmin, isStaff, reservation, resource, t, unit, paymentUrlData
+      isAdmin, reservation, resource, t, unit, paymentUrlData
     } = this.props;
 
     const nameSeparator = isEmpty(resource) || isEmpty(unit) ? '' : ', ';
@@ -63,7 +63,6 @@ class ReservationListItem extends Component {
         <div className="col-xs-12 col-sm-4 col-md-4 col-lg-3 action-container">
           <ReservationControls
             isAdmin={isAdmin}
-            isStaff={isStaff}
             paymentUrlData={paymentUrlData}
             reservation={reservation}
             resource={resource}
@@ -76,7 +75,6 @@ class ReservationListItem extends Component {
 
 ReservationListItem.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   reservation: PropTypes.object.isRequired,
   resource: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.spec.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.spec.js
@@ -16,7 +16,6 @@ import ReservationListItem from './ReservationListItem';
 describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
   const props = {
     isAdmin: false,
-    isStaff: false,
     reservation: Immutable(Reservation.build()),
     resource: Immutable(Resource.build({
       images: [Image.build()],
@@ -105,7 +104,6 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
       const actualProps = component.find(ReservationControls).props();
 
       expect(actualProps.isAdmin).toBe(false);
-      expect(actualProps.isStaff).toBe(false);
       expect(actualProps.reservation).toBe(props.reservation);
       expect(actualProps.resource).toBe(props.resource);
     });

--- a/app/pages/user-reservations/reservation-list/reservationListSelector.js
+++ b/app/pages/user-reservations/reservation-list/reservationListSelector.js
@@ -3,7 +3,7 @@ import ActionTypes from 'constants/ActionTypes';
 import { filter, orderBy, values } from 'lodash';
 import { createSelector, createStructuredSelector } from 'reselect';
 
-import { isAdminSelector, staffUnitsSelector } from 'state/selectors/authSelectors';
+import { isAdminSelector } from 'state/selectors/authSelectors';
 import { resourcesSelector, unitsSelector } from 'state/selectors/dataSelectors';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
 
@@ -21,7 +21,6 @@ const reservationListSelector = createStructuredSelector({
   isFetchingReservations: requestIsActiveSelectorFactory(ActionTypes.API.RESERVATIONS_GET_REQUEST),
   reservations: sortedReservationsSelector,
   resources: resourcesSelector,
-  staffUnits: staffUnitsSelector,
   units: unitsSelector,
 });
 

--- a/app/pages/user-reservations/reservation-list/reservationListSelector.spec.js
+++ b/app/pages/user-reservations/reservation-list/reservationListSelector.spec.js
@@ -24,10 +24,6 @@ describe('pages/user-reservations/reservation-list/reservationListSelector', () 
     expect(getSelected().resources).toBeDefined();
   });
 
-  test('returns staffUnits', () => {
-    expect(getSelected().staffUnits).toBeDefined();
-  });
-
   test('returns units from the state', () => {
     expect(getSelected().units).toBeDefined();
   });

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -67,7 +67,7 @@ class ReservationControls extends Component {
     };
   }
 
-  renderButtons(buttons, isAdmin, isStaff, reservation, canModify, canDelete, paymentUrlData) {
+  renderButtons(buttons, isAdmin, reservation, canModify, canDelete, paymentUrlData) {
     if (!reservation.needManualConfirmation) {
       if (reservation.state === 'cancelled') {
         return null;
@@ -91,7 +91,7 @@ class ReservationControls extends Component {
 
       case 'confirmed': {
         if (isAdmin) {
-          return isStaff
+          return canModify
             ? [buttons.cancel, buttons.edit]
             : [buttons.cancel];
         }
@@ -120,9 +120,7 @@ class ReservationControls extends Component {
 
       case 'requested': {
         if (isAdmin) {
-          return isStaff
-            ? [buttons.confirm, buttons.deny, buttons.edit]
-            : [buttons.edit];
+          return [buttons.edit];
         }
         return [buttons.edit, buttons.cancel];
       }
@@ -135,7 +133,7 @@ class ReservationControls extends Component {
 
   render() {
     const {
-      isAdmin, isStaff, paymentUrlData, reservation
+      isAdmin, paymentUrlData, reservation
     } = this.props;
 
     /*
@@ -155,7 +153,7 @@ class ReservationControls extends Component {
       <div className="buttons">
         {this.buttons.info}
         {this.renderButtons(
-          this.buttons, isAdmin, isStaff, reservation, canModify, canDelete, paymentUrlData
+          this.buttons, isAdmin, reservation, canModify, canDelete, paymentUrlData
         )}
       </div>
     );
@@ -164,7 +162,6 @@ class ReservationControls extends Component {
 
 ReservationControls.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   onCancelClick: PropTypes.func.isRequired,
   onConfirmClick: PropTypes.func.isRequired,
   onDenyClick: PropTypes.func.isRequired,

--- a/app/shared/reservation-controls/ReservationControls.spec.js
+++ b/app/shared/reservation-controls/ReservationControls.spec.js
@@ -16,10 +16,9 @@ describe('shared/reservation-controls/ReservationControls', () => {
   const onInfoClick = simple.stub();
   const onPayClick = simple.stub();
 
-  function getWrapper(reservation, isAdmin = false, isStaff = false, paymentUrlData = {}) {
+  function getWrapper(reservation, isAdmin = false, paymentUrlData = {}) {
     const props = {
       isAdmin,
-      isStaff,
       onCancelClick,
       onConfirmClick,
       onDenyClick,
@@ -101,52 +100,6 @@ describe('shared/reservation-controls/ReservationControls', () => {
       });
     });
 
-    describe('with preliminary reservation in requested state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'requested' });
-
-      describe('if user has staff permissions', () => {
-        const isStaff = true;
-        const buttons = getWrapper(reservation, isAdmin, isStaff).find(Button);
-
-        test('renders four buttons', () => {
-          expect(buttons.length).toBe(4);
-        });
-
-        describe('the first button', () => {
-          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
-        });
-
-        describe('the second button', () => {
-          makeButtonTests(buttons.at(1), 'confirm', 'ReservationControls.confirm', onConfirmClick);
-        });
-
-        describe('the third button', () => {
-          makeButtonTests(buttons.at(2), 'deny', 'ReservationControls.deny', onDenyClick);
-        });
-
-        describe('the fourth button', () => {
-          makeButtonTests(buttons.at(3), 'edit', 'ReservationControls.edit', onEditClick);
-        });
-      });
-
-      describe('if user does not have staff permissions', () => {
-        const isStaff = false;
-        const buttons = getWrapper(reservation, isAdmin, isStaff).find(Button);
-
-        test('renders two buttons', () => {
-          expect(buttons.length).toBe(2);
-        });
-
-        describe('the first button', () => {
-          makeButtonTests(buttons.at(0), 'info', 'ReservationControls.info', onInfoClick);
-        });
-
-        describe('the second button', () => {
-          makeButtonTests(buttons.at(1), 'edit', 'ReservationControls.edit', onEditClick);
-        });
-      });
-    });
-
     describe('with preliminary reservation in cancelled state', () => {
       const reservation = Reservation.build({ needManualConfirmation: true, state: 'cancelled' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
@@ -174,11 +127,14 @@ describe('shared/reservation-controls/ReservationControls', () => {
     });
 
     describe('with preliminary reservation in confirmed state', () => {
-      const reservation = Reservation.build({ needManualConfirmation: true, state: 'confirmed' });
-
-      describe('if user has staff permissions', () => {
-        const isStaff = true;
-        const buttons = getWrapper(reservation, isAdmin, isStaff).find(Button);
+      describe('if user has can modify reservation permission', () => {
+        const userPermissions = { canModify: true };
+        const reservation = Reservation.build({
+          needManualConfirmation: true,
+          state: 'confirmed',
+          userPermissions
+        });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
 
         test('renders three buttons', () => {
           expect(buttons.length).toBe(3);
@@ -197,9 +153,14 @@ describe('shared/reservation-controls/ReservationControls', () => {
         });
       });
 
-      describe('if user does not have staff permissions', () => {
-        const isStaff = false;
-        const buttons = getWrapper(reservation, isAdmin, isStaff).find(Button);
+      describe('if user does not have can modify reservation permission', () => {
+        const userPermissions = { canModify: false };
+        const reservation = Reservation.build({
+          needManualConfirmation: true,
+          state: 'confirmed',
+          userPermissions
+        });
+        const buttons = getWrapper(reservation, isAdmin).find(Button);
 
         test('renders two buttons', () => {
           expect(buttons.length).toBe(2);
@@ -218,7 +179,6 @@ describe('shared/reservation-controls/ReservationControls', () => {
 
   describe('if user is not an admin', () => {
     const isAdmin = false;
-    const isStaff = false;
 
     describe('with regular reservation', () => {
       describe('without reservation user permissions', () => {
@@ -382,7 +342,7 @@ describe('shared/reservation-controls/ReservationControls', () => {
 
       describe('when paymentUrlData is defined and its reservation id matches given reservation id', () => {
         const paymentUrlData = { paymentUrl: 'https://google.fi', reservationId: reservation.id };
-        const buttons = getWrapper(reservation, isAdmin, isStaff, paymentUrlData).find(Button);
+        const buttons = getWrapper(reservation, isAdmin, paymentUrlData).find(Button);
         test('renders two buttons', () => {
           expect(buttons.length).toBe(2);
         });

--- a/app/shared/reservation-controls/ReservationControlsContainer.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.js
@@ -78,13 +78,12 @@ export class UnconnectedReservationControlsContainer extends Component {
 
   render() {
     const {
-      isAdmin, isStaff, reservation, paymentUrlData
+      isAdmin, reservation, paymentUrlData
     } = this.props;
 
     return (
       <ReservationControls
         isAdmin={isAdmin}
-        isStaff={isStaff}
         onCancelClick={this.handleCancelClick}
         onConfirmClick={this.handleConfirmClick}
         onDenyClick={this.handleDenyClick}
@@ -101,7 +100,6 @@ export class UnconnectedReservationControlsContainer extends Component {
 UnconnectedReservationControlsContainer.propTypes = {
   actions: PropTypes.object.isRequired,
   isAdmin: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   reservation: PropTypes.object.isRequired,
   resource: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,

--- a/app/shared/reservation-controls/ReservationControlsContainer.spec.js
+++ b/app/shared/reservation-controls/ReservationControlsContainer.spec.js
@@ -28,7 +28,6 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       showReservationInfoModal: simple.stub(),
     },
     isAdmin: false,
-    isStaff: false,
     reservation,
     resource,
   };
@@ -50,7 +49,6 @@ describe('shared/reservation-controls/ReservationControlsContainer', () => {
       const actualProps = container.find(ReservationControls).props();
 
       expect(actualProps.isAdmin).toBe(props.isAdmin);
-      expect(actualProps.isStaff).toBe(props.isStaff);
       expect(actualProps.onCancelClick).toBe(instance.handleCancelClick);
       expect(actualProps.onConfirmClick).toBe(instance.handleConfirmClick);
       expect(actualProps.onDenyClick).toBe(instance.handleDenyClick);


### PR DESCRIPTION
Removed old isStaff checks which used `can_approve_reservation` perm and replaced it with reservation `can_modify` perm in user reservations page. This fixes staff not having access to modify reservation button in my reservations page for manually confirmed reservations.