### PR TITLE
Fixed staff's skip mandatory pricing with cgs

### DIFF
--- a/app/pages/reservation/ReservationPage.js
+++ b/app/pages/reservation/ReservationPage.js
@@ -307,7 +307,9 @@ class UnconnectedReservationPage extends Component {
   }
 
   HandleToggleMandatoryProducts() {
-    const { skipMandatoryProducts, mandatoryProducts, extraProducts } = this.state;
+    const {
+      skipMandatoryProducts, mandatoryProducts, extraProducts, currentCustomerGroup
+    } = this.state;
     const { resource, selected } = this.props;
     const quantity = skipMandatoryProducts ? 1 : 0;
     const updatedMandatoryProducts = mandatoryProducts.map(
@@ -318,7 +320,7 @@ class UnconnectedReservationPage extends Component {
       skipMandatoryProducts: !prevState.skipMandatoryProducts,
     }));
     this.handleCheckOrderPrice(
-      resource, selected, updatedMandatoryProducts, extraProducts
+      resource, selected, updatedMandatoryProducts, extraProducts, false, currentCustomerGroup
     );
   }
 

--- a/app/pages/reservation/ReservationPage.spec.js
+++ b/app/pages/reservation/ReservationPage.spec.js
@@ -980,13 +980,15 @@ describe('pages/reservation/ReservationPage', () => {
     test('calls handleCheckOrderPrice', () => {
       const instance = getWrapper({ resource: resourceA }).instance();
       const spy = jest.spyOn(instance, 'handleCheckOrderPrice');
+      const customerGroupId = 'cg-id-1';
+      instance.state.currentCustomerGroup = customerGroupId;
       instance.state.mandatoryProducts = mandatoryProducts;
       instance.state.extraProducts = extraProducts;
       instance.HandleToggleMandatoryProducts();
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(
-        resourceA, defaultProps.selected,
-        instance.state.mandatoryProducts, instance.state.extraProducts
+        resourceA, defaultProps.selected, instance.state.mandatoryProducts,
+        instance.state.extraProducts, false, customerGroupId
       );
     });
   });


### PR DESCRIPTION
Added currently selected customer group to staff's skip mandatory products order price check call in reservation page. This fixes incorrect price being shown for staff when using skip mandatory products and customer groups at the same time.