### PR TITLE
Added support for fixed price time slots

### DIFF
--- a/app/pages/reservation/reservation-products/ReservationProductsUtils.js
+++ b/app/pages/reservation/reservation-products/ReservationProductsUtils.js
@@ -3,6 +3,11 @@ export const PRODUCT_TYPES = {
   EXTRA: 'extra'
 };
 
+export const PRODUCT_PRICE_TYPES = {
+  FIXED: 'fixed',
+  PER_PERIOD: 'per_period'
+};
+
 export function getRoundedVat(vat) {
   return Math.round(parseInt(vat, 10));
 }

--- a/app/pages/reservation/reservation-products/product-time-slots/ProductTimeSlotPrices.js
+++ b/app/pages/reservation/reservation-products/product-time-slots/ProductTimeSlotPrices.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
 
 import { getPrettifiedPeriodUnits } from 'utils/timeUtils';
-import { getTimeSlotMinMaxPrices } from '../ReservationProductsUtils';
+import { getTimeSlotMinMaxPrices, PRODUCT_PRICE_TYPES } from '../ReservationProductsUtils';
 import injectT from '../../../../i18n/injectT';
 import TimeSlotPrice from './TimeSlotPrice';
 
@@ -20,12 +20,13 @@ function ProductTimeSlotPrices({ orderLine, t, timeSlotPrices }) {
   const type = orderLine.product.price.type;
   const period = orderLine.product.price.period;
   const { min, max } = getTimeSlotMinMaxPrices(timeSlotPrices, basePrice);
+  const priceUnit = type !== PRODUCT_PRICE_TYPES.FIXED ? `€ / ${getPrettifiedPeriodUnits(period)}` : '€';
   if (timeSlotPrices.length > 0) {
     return (
       <Panel className="pricing-expandable-panel" defaultExpanded={false}>
         <Panel.Heading>
           <Panel.Title toggle>
-            {`${t('ReservationProducts.timeSlots.prices')} ${min}–${max} € / ${getPrettifiedPeriodUnits(period)}`}
+            {`${t('ReservationProducts.timeSlots.prices')} ${min}–${max} ${priceUnit}`}
           </Panel.Title>
         </Panel.Heading>
         <Panel.Collapse>
@@ -34,10 +35,10 @@ function ProductTimeSlotPrices({ orderLine, t, timeSlotPrices }) {
               <TimeSlotPrice
                 begin={timeSlotPrice.begin}
                 end={timeSlotPrice.end}
-                id={timeSlotPrice.id}
                 key={`time-slot-price-${timeSlotPrice.id}`}
                 period={period}
                 price={timeSlotPrice.price}
+                priceUnit={priceUnit}
               />
             ))}
             <li>

--- a/app/pages/reservation/reservation-products/product-time-slots/TimeSlotPrice.js
+++ b/app/pages/reservation/reservation-products/product-time-slots/TimeSlotPrice.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { formatTime, getPrettifiedPeriodUnits } from '../../../../utils/timeUtils';
+import { formatTime } from '../../../../utils/timeUtils';
 
 /**
  * Renders a single time slot price list element
@@ -9,11 +9,11 @@ import { formatTime, getPrettifiedPeriodUnits } from '../../../../utils/timeUtil
  * @param {string} props.begin
  * @param {string} props.end
  * @param {string} props.price
- * @param {string} props.period
+ * @param {string} props.priceUnit
  * @returns {JSX.Element}
  */
 function TimeSlotPrice({
-  begin, end, price, period
+  begin, end, price, priceUnit
 }) {
   const initialTimeFormat = 'HH:mm:ss';
   const targetTimeFormat = 'HH:mm';
@@ -23,7 +23,7 @@ function TimeSlotPrice({
         begin, initialTimeFormat, targetTimeFormat
       )}–${formatTime(
         end, initialTimeFormat, targetTimeFormat
-      )}:⠀${price} € / ${getPrettifiedPeriodUnits(period)}`}
+      )}:⠀${price} ${priceUnit}`}
     </li>
   );
 }
@@ -32,7 +32,7 @@ TimeSlotPrice.propTypes = {
   begin: PropTypes.string.isRequired,
   end: PropTypes.string.isRequired,
   price: PropTypes.string.isRequired,
-  period: PropTypes.string.isRequired
+  priceUnit: PropTypes.string.isRequired
 };
 
 export default TimeSlotPrice;

--- a/app/pages/reservation/reservation-products/product-time-slots/tests/TimeSlotPrice.spec.js
+++ b/app/pages/reservation/reservation-products/product-time-slots/tests/TimeSlotPrice.spec.js
@@ -8,7 +8,7 @@ describe('reservation-products/product-time-slots/TimeSlotPrice', () => {
     begin: '08:00:00',
     end: '12:00:00',
     price: '3.50',
-    period: '00:30:00',
+    priceUnit: '€ / 30min',
   };
 
   function getWrapper(extraProps) {


### PR DESCRIPTION
# Support for fixed price time slots

## Time slot prices use correct units based on price type

### [Related Trello card](https://trello.com/c/DKu92t3B)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fixed price time slots
 1. app/pages/reservation/reservation-products/ReservationProductsUtils.js
     * New constants for price types

 2. app/pages/reservation/reservation-products/product-time-slots/ProductTimeSlotPrices.js
     * Added support for fixed price type

 3. app/pages/reservation/reservation-products/product-time-slots/TimeSlotPrice.js
     * Changed price units to be used directly from props instead of figuring them in the component