### PR TITLE
Changed reservation confirmation feedback url

### DIFF
--- a/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
+++ b/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
@@ -62,7 +62,10 @@ class ReservationConfirmation extends Component {
       currentLanguage, isEdited, isLoggedIn, reservation, resource, t, user
     } = this.props;
 
-    const href = getFeedbackLink(currentLanguage);
+    // if resource has feedback url defined, use it instead of default urls
+    const resourceFeedbackUrl = 'reservationFeedbackUrl' in resource ? resource.reservationFeedbackUrl : '';
+    const href = resourceFeedbackUrl || getFeedbackLink(currentLanguage);
+
     const customerGroupName = getReservationCustomerGroupName(reservation, currentLanguage);
     let email = '';
     if (reservation.reserverEmailAddress) {

--- a/app/pages/reservation/reservation-confirmation/ReservationConfirmation.spec.js
+++ b/app/pages/reservation/reservation-confirmation/ReservationConfirmation.spec.js
@@ -147,6 +147,17 @@ describe('pages/reservation/reservation-confirmation/ReservationConfirmation', (
       expect(link.length).toBe(1);
       expect(link.prop('values')).toEqual({ href: constants.FEEDBACK_URL.EN });
     });
+
+    test('when resource has a defined reservation feedback url', () => {
+      const testFeedbackUrl = 'https://test-feedback.fi';
+      const resource = Resource.build({ reservationFeedbackUrl: testFeedbackUrl });
+      const link = getWrapper({ currentLanguage: 'en', resource })
+        .find(FormattedHTMLMessage)
+        .filter({ id: 'ReservationConfirmation.feedbackText' });
+
+      expect(link.length).toBe(1);
+      expect(link.prop('values')).toEqual({ href: testFeedbackUrl });
+    });
   });
 
   test('renders reservation.user.email', () => {


### PR DESCRIPTION
# Reservation confirmation feedback URL

## Added support for reservation feedback URL defined in resource which takes priority over default feedback URLs in reservation confirmation page

### [Related Trello card](https://trello.com/c/z9JtGogV)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Reservation confirmation feedback URL
 1. app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
     * Added support for reservation feedback URL defined in resource