### PR TITLE
Changed map tile URLs

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -26,8 +26,8 @@ const constants = {
     MAX_SHOWN_PAGINATION_BUTTONS: 9,
   },
   MAP_TILE_URLS: {
-    DEFAULT_TILES: 'https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}.png',
-    HIGH_CONTRAST_TILES: 'https://maptiles.turku.fi/styles/hel-osm-high-contrast/{z}/{x}/{y}.png'
+    DEFAULT_TILES: 'https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}',
+    HIGH_CONTRAST_TILES: 'https://maptiles.turku.fi/styles/high-contrast-map-layer/{z}/{x}/{y}'
   },
   NAV_ADMIN_URLS: {
     gitbook: 'https://city-of-turku.gitbook.io/varaamo-turku/',

--- a/app/shared/resource-map/MapContainer.js
+++ b/app/shared/resource-map/MapContainer.js
@@ -31,6 +31,7 @@ export class UnconnectedResourceMapContainer extends React.Component {
       maxLongitude: PropTypes.number,
       minLongitude: PropTypes.number,
     }),
+    currentLanguage: PropTypes.string.isRequired,
     markers: PropTypes.array,
     useHighContrast: PropTypes.bool.isRequired,
     position: PropTypes.object,
@@ -91,7 +92,9 @@ export class UnconnectedResourceMapContainer extends React.Component {
   }
 
   render() {
-    const { useHighContrast } = this.props;
+    const { useHighContrast, currentLanguage } = this.props;
+    const mapLanguage = currentLanguage === 'sv' ? 'sv' : 'fi';
+    const mapUrl = `${useHighContrast ? highContrastTilesUrl : defaultTilesUrl}@${mapLanguage}.png`;
 
     return (
       <div className={classNames('app-ResourceMap', { 'app-ResourceMap__showMap': this.props.showMap })}>
@@ -105,7 +108,7 @@ export class UnconnectedResourceMapContainer extends React.Component {
         >
           <TileLayer
             attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-            url={useHighContrast ? highContrastTilesUrl : defaultTilesUrl}
+            url={mapUrl}
           />
           <ZoomControl position="bottomright" />
           {this.props.markers && this.props.markers.map(

--- a/app/shared/resource-map/MapContainer.spec.js
+++ b/app/shared/resource-map/MapContainer.spec.js
@@ -17,6 +17,7 @@ describe('shared/resource-map/MapContainer', () => {
         maxLongitude: 0,
         minLongitude: 0,
       },
+      currentLanguage: 'fi',
       useHighContrast: false,
       searchMapClick: () => {},
       selectedUnitId: null,
@@ -62,14 +63,26 @@ describe('shared/resource-map/MapContainer', () => {
       const tileLayer = getWrapper({ useHighContrast: true }).find(TileLayer);
       expect(tileLayer.length).toBe(1);
       expect(tileLayer.prop('attribution')).toEqual('© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors');
-      expect(tileLayer.prop('url')).toEqual('https://maptiles.turku.fi/styles/hel-osm-high-contrast/{z}/{x}/{y}.png');
+      expect(tileLayer.prop('url')).toEqual('https://maptiles.turku.fi/styles/high-contrast-map-layer/{z}/{x}/{y}@fi.png');
     });
 
     test('is rendered with correct props when high contrast is not in use', () => {
       const tileLayer = getWrapper({ useHighContrast: false }).find(TileLayer);
       expect(tileLayer.length).toBe(1);
       expect(tileLayer.prop('attribution')).toEqual('© <a href="http://osm.org/copyright">OpenStreetMap</a> contributors');
-      expect(tileLayer.prop('url')).toEqual('https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}.png');
+      expect(tileLayer.prop('url')).toEqual('https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}@fi.png');
+    });
+
+    test.each([
+      ['fi', 'fi'],
+      ['sv', 'sv'],
+      ['en', 'fi'],
+      ['xy', 'fi'],
+    ])('is rendered with correct language map', (lang, expectedMapLang) => {
+      const tileLayer = getWrapper({ currentLanguage: lang }).find(TileLayer);
+      expect(tileLayer.prop('url')).toEqual(
+        `https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}@${expectedMapLang}.png`
+      );
     });
   });
 

--- a/app/shared/resource-map/mapSelector.js
+++ b/app/shared/resource-map/mapSelector.js
@@ -5,6 +5,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 
 import { resourcesSelector, unitsSelector } from 'state/selectors/dataSelectors';
 import urlSearchFiltersSelector from 'state/selectors/urlSearchFiltersSelector';
+import { currentLanguageSelector } from 'state/selectors/translationSelectors';
 
 const contrastSelector = state => state.ui.accessibility.isHighContrast;
 const positionSelector = state => state.ui.search.position;
@@ -83,6 +84,7 @@ const boundariesSelector = createSelector(
 
 export default createStructuredSelector({
   boundaries: boundariesSelector,
+  currentLanguage: currentLanguageSelector,
   useHighContrast: contrastSelector,
   shouldMapFitBoundaries: shouldMapFitBoundariesSelector,
   markers: markersSelector,

--- a/app/shared/resource-map/mapSelector.spec.js
+++ b/app/shared/resource-map/mapSelector.spec.js
@@ -156,6 +156,16 @@ describe('shared/resource-map/mapSelector', () => {
     });
   });
 
+  describe('currentLanguage', () => {
+    test('is defined', () => {
+      const state = getState();
+      const props = getProps({ resourceIds: ['123'] });
+      const selected = selector(state, props);
+
+      expect(selected.currentLanguage).toBeDefined();
+    });
+  });
+
   describe('isHighContrast', () => {
     test('is defined', () => {
       const state = getState();


### PR DESCRIPTION
# New high contrast map tiles and sv language support

## Changed old broken high contrast map tiles to new ones and added support for sv language tiles

### [Related Trello card](https://trello.com/c/1QRmhEU5)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Map tile update
 1. app/constants/AppConstants.js
     * new high contrast map tile base url
     * removed `.png` from map tile urls which is now added later
   
 2. app/shared/resource-map/MapContainer.js
     * added support for languages for map tiles
    
 3. app/shared/resource-map/mapSelector.js
     * added current language selector to allow map tiles to be shown with different languages