### PR TITLE
Changed all orderLine.price to orderLine.rounded_price

### DIFF
--- a/app/pages/reservation/reservation-products/MobileProduct.js
+++ b/app/pages/reservation/reservation-products/MobileProduct.js
@@ -23,7 +23,8 @@ const ORDER_TYPE = {
     }),
     type: PropTypes.string,
   }),
-  price: PropTypes.string,
+  price: PropTypes.number,
+  rounded_price: PropTypes.string,
   quantity: PropTypes.number,
 };
 
@@ -36,7 +37,7 @@ const ORDER_TYPE = {
  * @returns {JSX.Element}
  */
 function MandatoryProduct({ filteredtimeSlotPrices, order, t }) {
-  const totalPrice = order.price;
+  const totalPrice = order.rounded_price;
   const {
     type, period, amount: basePrice, tax_percentage: vat
   } = order.product.price;
@@ -79,7 +80,7 @@ function ExtraProduct({
   filteredtimeSlotPrices, order, t, handleChange
 }) {
   const { amount: unitPrice, tax_percentage: vat } = order.product.price;
-  const { quantity, price: totalPrice } = order;
+  const { quantity, rounded_price: totalPrice } = order;
   const maxQuantity = order.product.max_quantity;
   const vatText = t('ReservationProducts.price.includesVat', { vat: getRoundedVat(vat) });
 

--- a/app/pages/reservation/reservation-products/ReservationProductsUtils.js
+++ b/app/pages/reservation/reservation-products/ReservationProductsUtils.js
@@ -40,7 +40,7 @@ export function calculateTax(price, taxPercentage) {
 
 /**
  * Calculates tax breakdown from order lines
- * @param {array} orderLines containing products, prices, quantities etc
+ * @param {Object[]} orderLines containing products, prices, quantities etc
  * @returns {object} tax breakdown
  */
 export function getOrderTaxTotals(orderLines) {
@@ -48,11 +48,11 @@ export function getOrderTaxTotals(orderLines) {
   orderLines.forEach((orderLine) => {
     if (orderLine.quantity > 0) {
       const taxPercentage = orderLine.product.price.tax_percentage;
-      const taxPrice = calculateTax(orderLine.price, taxPercentage);
+      const taxPrice = calculateTax(orderLine.rounded_price, taxPercentage);
       const taxData = {
         taxPercentage,
         taxPrice,
-        taxlessPrice: orderLine.price - taxPrice,
+        taxlessPrice: orderLine.rounded_price - taxPrice,
       };
       orderTaxData.push(taxData);
     }

--- a/app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js
+++ b/app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js
@@ -60,7 +60,7 @@ ExtraProductTableRow.propTypes = {
   currentLanguage: PropTypes.string.isRequired,
   handleQuantityChange: PropTypes.func.isRequired,
   orderLine: PropTypes.shape({
-    rounded_price: PropTypes.number,
+    rounded_price: PropTypes.string,
     product: PropTypes.object,
   }),
   t: PropTypes.func.isRequired,

--- a/app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js
+++ b/app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js
@@ -11,7 +11,7 @@ import ProductTimeSlotPrices from '../product-time-slots/ProductTimeSlotPrices';
 function ExtraProductTableRow({
   currentCustomerGroup, currentLanguage, orderLine, handleQuantityChange, t
 }) {
-  const totalPrice = orderLine.price;
+  const totalPrice = orderLine.rounded_price;
   const name = getLocalizedFieldValue(orderLine.product.name, currentLanguage, true);
   const maxQuantity = orderLine.product.max_quantity;
 
@@ -59,7 +59,10 @@ ExtraProductTableRow.propTypes = {
   currentCustomerGroup: PropTypes.string.isRequired,
   currentLanguage: PropTypes.string.isRequired,
   handleQuantityChange: PropTypes.func.isRequired,
-  orderLine: PropTypes.object.isRequired,
+  orderLine: PropTypes.shape({
+    rounded_price: PropTypes.number,
+    product: PropTypes.object,
+  }),
   t: PropTypes.func.isRequired,
 };
 

--- a/app/pages/reservation/reservation-products/extra-products/tests/ExtraProductTableRow.spec.js
+++ b/app/pages/reservation/reservation-products/extra-products/tests/ExtraProductTableRow.spec.js
@@ -81,7 +81,7 @@ describe('reservation-products/extra-products/ExtraProductTableRow', () => {
 
     test('fourth table data has correct data', () => {
       const fourth = tableDatas.at(3);
-      const totalPrice = defaultProps.orderLine.price;
+      const totalPrice = defaultProps.orderLine.rounded_price;
       expect(fourth.text()).toBe(`${totalPrice} € ReservationProducts.price.includesVat`);
     });
   });

--- a/app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js
@@ -49,7 +49,7 @@ MandatoryProductTableRow.propTypes = {
   currentCustomerGroup: PropTypes.string.isRequired,
   currentLanguage: PropTypes.string.isRequired,
   orderLine: PropTypes.shape({
-    rounded_price: PropTypes.number,
+    rounded_price: PropTypes.string,
     product: PropTypes.object,
   }),
   t: PropTypes.func.isRequired,

--- a/app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js
@@ -12,7 +12,7 @@ function MandatoryProductTableRow({
 }) {
   const name = getLocalizedFieldValue(orderLine.product.name, currentLanguage, true);
   const basePrice = orderLine.product.price.amount;
-  const totalPrice = orderLine.price;
+  const totalPrice = orderLine.rounded_price;
 
   const type = orderLine.product.price.type;
   const period = orderLine.product.price.period;
@@ -48,7 +48,10 @@ function MandatoryProductTableRow({
 MandatoryProductTableRow.propTypes = {
   currentCustomerGroup: PropTypes.string.isRequired,
   currentLanguage: PropTypes.string.isRequired,
-  orderLine: PropTypes.object.isRequired,
+  orderLine: PropTypes.shape({
+    rounded_price: PropTypes.number,
+    product: PropTypes.object,
+  }),
   t: PropTypes.func.isRequired,
 };
 

--- a/app/pages/reservation/reservation-products/mandatory-products/tests/MandatoryProductTableRow.spec.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/tests/MandatoryProductTableRow.spec.js
@@ -71,7 +71,7 @@ describe('reservation-products/mandatory-products/MandatoryProductTableRow', () 
 
     test('third table data has correct data', () => {
       const third = tableDatas.at(2);
-      const totalPrice = defaultProps.orderLine.price;
+      const totalPrice = defaultProps.orderLine.rounded_price;
       expect(third.text()).toBe(`${totalPrice} € ReservationProducts.price.includesVat`);
     });
   });

--- a/app/pages/reservation/reservation-products/tests/MobileProduct.spec.js
+++ b/app/pages/reservation/reservation-products/tests/MobileProduct.spec.js
@@ -29,19 +29,20 @@ describe('reservation-products/MobileProduct', () => {
           type: 'fixed', tax_percentage: '24.00', amount: '8.00'
         }
       });
+      const order = OrderLine.build({
+        product: rentProduct,
+        price: 8.00,
+        quantity: 1
+      });
       const wrapper = getWrapper(
         {
-          order: OrderLine.build({
-            product: rentProduct,
-            price: '8.00',
-            quantity: 1
-          })
+          order
         }
       );
       const expectedValues = [
         rentProduct.name[defaultProps.currentLanguage],
-        `ReservationProducts.table.heading.price: ${rentProduct.price.amount} €`,
-        `ReservationProducts.table.heading.total: ${rentProduct.price.amount} € ReservationProducts.price.includesVat`,
+        `ReservationProducts.table.heading.price: ${order.rounded_price} €`,
+        `ReservationProducts.table.heading.total: ${order.rounded_price} € ReservationProducts.price.includesVat`,
       ];
       expect(wrapper.find('p')).toHaveLength(3);
       wrapper.find('p').forEach((element, index) => {
@@ -59,23 +60,21 @@ describe('reservation-products/MobileProduct', () => {
           type: 'per_period', tax_percentage: '24.00', amount: '10.00', period: '00:30:00'
         }
       });
-      const orderPrice = '50.00';
-      // eslint-disable-next-line max-len
-      const orderQuantity = Number.parseInt(orderPrice, 10) / Number.parseInt(rentProduct.price.amount, 10);
-
+      const orderPrice = 50.00;
+      const order = OrderLine.build({
+        product: rentProduct,
+        price: orderPrice,
+        quantity: orderPrice / Number.parseInt(rentProduct.price.amount, 10)
+      });
       const wrapper = getWrapper(
         {
-          order: OrderLine.build({
-            product: rentProduct,
-            price: orderPrice,
-            quantity: orderQuantity,
-          })
+          order
         }
       );
       const expectedValues = [
         rentProduct.name[defaultProps.currentLanguage],
         `ReservationProducts.table.heading.price: ${rentProduct.price.amount} € / ${getPrettifiedPeriodUnits(rentProduct.price.period)}`,
-        `ReservationProducts.table.heading.total: ${orderPrice} € ReservationProducts.price.includesVat`,
+        `ReservationProducts.table.heading.total: ${order.rounded_price} € ReservationProducts.price.includesVat`,
       ];
       expect(wrapper.find('p')).toHaveLength(3);
       wrapper.find('p').forEach((element, index) => {
@@ -92,23 +91,21 @@ describe('reservation-products/MobileProduct', () => {
         },
         max_quantity: 10,
       });
-      const orderPrice = '45.00';
-      // eslint-disable-next-line max-len
-      const orderQuantity = Number.parseInt(orderPrice, 10) / Number.parseInt(extraProduct.price.amount, 10);
-
+      const orderPrice = 45.00;
+      const order = OrderLine.build({
+        product: extraProduct,
+        price: orderPrice,
+        quantity: orderPrice / Number.parseInt(extraProduct.price.amount, 10)
+      });
       const wrapper = getWrapper(
         {
-          order: OrderLine.build({
-            product: extraProduct,
-            price: orderPrice,
-            quantity: orderQuantity
-          })
+          order
         }
       );
       const expectedValues = [
         extraProduct.name[defaultProps.currentLanguage],
         `ReservationProducts.table.heading.unitPrice: ${extraProduct.price.amount} €`,
-        `ReservationProducts.table.heading.total: ${orderPrice} € ReservationProducts.price.includesVat`,
+        `ReservationProducts.table.heading.total: ${order.rounded_price} € ReservationProducts.price.includesVat`,
       ];
       expect(wrapper.find('p')).toHaveLength(3);
       wrapper.find('p').forEach((element, index) => {
@@ -121,7 +118,7 @@ describe('reservation-products/MobileProduct', () => {
       expect(quantityElement.prop('handleAdd')).toBeDefined();
       expect(quantityElement.prop('handleReduce')).toBeDefined();
       expect(quantityElement.prop('maxQuantity')).toEqual(extraProduct.max_quantity);
-      expect(quantityElement.prop('quantity')).toEqual(orderQuantity);
+      expect(quantityElement.prop('quantity')).toEqual(order.quantity);
     });
 
     describe('when product contains time slot prices', () => {

--- a/app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js
+++ b/app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js
@@ -44,9 +44,9 @@ describe('reservation-products/ProductsSummary', () => {
     max_quantity: 1,
   });
   const orderLines = [
-    OrderLine.build({ product: rentProduct, quantity: 1, price: '8.00' }),
-    OrderLine.build({ product: extraProductOne, quantity: 3, price: '45.00' }),
-    OrderLine.build({ product: extraProductTwo, quantity: 1, price: '55.00' }),
+    OrderLine.build({ product: rentProduct, quantity: 1, price: 8.00 }),
+    OrderLine.build({ product: extraProductOne, quantity: 3, price: 45.00 }),
+    OrderLine.build({ product: extraProductTwo, quantity: 1, price: 55.00 }),
   ];
   const defaultProps = {
     changeProductQuantity: () => {},

--- a/app/shared/modals/reservation-info/ReservationOrderInfo.js
+++ b/app/shared/modals/reservation-info/ReservationOrderInfo.js
@@ -17,7 +17,7 @@ function ReservationOrderInfo({
     const name = getLocalizedFieldValue(orderLine.product.name, currentLanguage, true);
     const quantity = `${orderLine.quantity} ${t('common.unitPieces', { unitPieces: orderLine.quantity })}`;
     const vat = getRoundedVat(orderLine.product.price.taxPercentage);
-    const totalPrice = `${t('common.total')} ${t('common.priceWithVAT', { price: orderLine.price, vat })}`;
+    const totalPrice = `${t('common.total')} ${t('common.priceWithVAT', { price: orderLine.roundedPrice, vat })}`;
     return (
       <React.Fragment key={orderLine.product.id}>
         {renderInfoRow(name, `${quantity}, ${totalPrice}`)}

--- a/app/utils/fixtures/OrderLine.js
+++ b/app/utils/fixtures/OrderLine.js
@@ -4,6 +4,7 @@ const OrderLine = new Factory()
   .attr('product', {})
   .attr('quantity', 0)
   .attr('unit_price', '8.00')
-  .attr('price', '0.00');
+  .attr('price', 0.00)
+  .attr('rounded_price', ['price'], price => Number(price).toFixed(2));
 
 export default OrderLine;


### PR DESCRIPTION
# Changed all orderLine.price to orderLine.rounded_price.


#### Changed all orderLine.price to orderLine.rounded_price. The price key returns an un-rounded number value which causes the site to display unnecessary decimals or no decimals at all, while rounded_price returns a correctly rounded string value with 2 decimals.
[Trello card for this feature.](https://trello.com/c/oXEiRfLI/328-korjataan-varaamon-tuotesivulla-yhteens%C3%A4-hintojen-py%C3%B6ristyksen-puuttuminen-ja-puuttuvat-desimaalit)

-----------------------------------------------------------------------------------------------
Changes:
- **app/pages/reservation/reservation-products/MobileProduct.js:**
Changed all `order.price` to the new `order.rounded_price`.

- **app/pages/reservation/reservation-products/tests/MobileProduct.spec.js:**
Refactored and updated tests to use the new `rounded_price` value.

- **app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js:**
Updated `OrderLine.build` to pass `price` as a `number` instead of a `string`.

- **app/pages/reservation/reservation-products/ReservationProductsUtils.js:**
Changed all `orderLine.price` to the new `orderLine.rounded_price`.

- **app/pages/reservation/reservation-products/extra-products/ExtraProductTableRow.js:**
Changed all `orderLine.price` to the new `orderLine.rounded_price`.

- **app/pages/reservation/reservation-products/extra-products/tests/ExtraProductTableRow.spec.js:**
Updated tests.

- **app/pages/reservation/reservation-products/mandatory-products/MandatoryProductTableRow.js:**
Changed all `orderLine.price` to the new `orderLine.rounded_price`.

- **...reservation-products/mandatory-products/tests/MandatoryProductTableRow.spec.js:**
Updated tests.

- **app/shared/modals/reservation-info/ReservationOrderInfo.js:**
Changed `orderLine.price` to `orderLine.roundedPrice`, for some reason the key is in camelCase in this file.
