### PR TITLE
Added customer group login method restriction handling

### DIFF
--- a/app/pages/reservation/ReservationPage.js
+++ b/app/pages/reservation/ReservationPage.js
@@ -35,7 +35,6 @@ import {
 } from '../../utils/reservationUtils';
 import userManager from 'utils/userManager';
 import ReservationProducts from './reservation-products/ReservationProducts';
-import { getUniqueCustomerGroups } from './reservation-products/ReservationProductsUtils';
 
 class UnconnectedReservationPage extends Component {
   constructor(props) {
@@ -77,7 +76,8 @@ class UnconnectedReservationPage extends Component {
       selected,
       history,
       isLoggedIn,
-      loginExpiresAt
+      loginExpiresAt,
+      uniqueCustomerGroups,
     } = this.props;
     if (
       isEmpty(reservationCreated)
@@ -98,8 +98,12 @@ class UnconnectedReservationPage extends Component {
       // handle price ops only when reservation info exists
       const isEditing = !isEmpty(reservationToEdit);
       const { mandatoryProducts, extraProducts } = this.state;
+
+      const initialCustomerGroup = uniqueCustomerGroups.length === 1 ? uniqueCustomerGroups[0].id : '';
+      this.setState({ currentCustomerGroup: initialCustomerGroup });
       this.handleCheckOrderPrice(
-        this.props.resource, selected, mandatoryProducts, extraProducts, isEditing
+        this.props.resource, selected, mandatoryProducts, extraProducts,
+        isEditing, initialCustomerGroup
       );
     }
 
@@ -186,15 +190,24 @@ class UnconnectedReservationPage extends Component {
 
   handleProductsConfirm = () => {
     const { currentCustomerGroup } = this.state;
-    const { resource } = this.props;
-    const uniqueCustomerGroups = getUniqueCustomerGroups(resource);
-
-    // handle order/products validation before going forward
-    // customer group is required when any of the resource's products have customer group options
-    if (uniqueCustomerGroups.length > 0 && !currentCustomerGroup) {
+    const { uniqueCustomerGroups } = this.props;
+    /*
+      Handle order/products validation before going forward.
+      Customer group is required when any of the resource's products have customer group
+      options that are not all hidden from the current user.
+    */
+    if (uniqueCustomerGroups.length > 1 && !currentCustomerGroup) {
       this.setState({ customerGroupError: true });
     } else {
-      this.setState({ view: 'information' });
+      if (uniqueCustomerGroups.length === 1) {
+        // handle auto selecting cg when there is only one option
+        this.setState({
+          view: 'information',
+          currentCustomerGroup: uniqueCustomerGroups[0].id
+        });
+      } else {
+        this.setState({ view: 'information' });
+      }
       window.scrollTo(0, 0);
     }
   };
@@ -421,6 +434,7 @@ class UnconnectedReservationPage extends Component {
       selected,
       t,
       unit,
+      uniqueCustomerGroups,
       user,
       history,
     } = this.props;
@@ -496,6 +510,7 @@ class UnconnectedReservationPage extends Component {
                     resource={resource}
                     selectedTime={selectedTime}
                     skipMandatoryProducts={skipMandatoryProducts}
+                    uniqueCustomerGroups={uniqueCustomerGroups}
                     unit={unit}
                   />
                 )}
@@ -563,7 +578,8 @@ UnconnectedReservationPage.propTypes = {
   user: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
-  loginExpiresAt: PropTypes.number
+  loginExpiresAt: PropTypes.number,
+  uniqueCustomerGroups: PropTypes.array.isRequired,
 };
 UnconnectedReservationPage = injectT(UnconnectedReservationPage); // eslint-disable-line
 

--- a/app/pages/reservation/ReservationPage.js
+++ b/app/pages/reservation/ReservationPage.js
@@ -97,10 +97,14 @@ class UnconnectedReservationPage extends Component {
     } else {
       // handle price ops only when reservation info exists
       const isEditing = !isEmpty(reservationToEdit);
-      const { mandatoryProducts, extraProducts } = this.state;
+      const { mandatoryProducts, extraProducts, currentCustomerGroup } = this.state;
 
-      const initialCustomerGroup = uniqueCustomerGroups.length === 1 ? uniqueCustomerGroups[0].id : '';
-      this.setState({ currentCustomerGroup: initialCustomerGroup });
+      const initialCustomerGroup = uniqueCustomerGroups.length === 1
+        ? uniqueCustomerGroups[0].id : currentCustomerGroup;
+
+      if (initialCustomerGroup) {
+        this.setState({ currentCustomerGroup: initialCustomerGroup });
+      }
       this.handleCheckOrderPrice(
         this.props.resource, selected, mandatoryProducts, extraProducts,
         isEditing, initialCustomerGroup

--- a/app/pages/reservation/ReservationPage.spec.js
+++ b/app/pages/reservation/ReservationPage.spec.js
@@ -469,6 +469,22 @@ describe('pages/reservation/ReservationPage', () => {
         expect(instanceA.handleCheckOrderPrice.lastCall.args[5]).toStrictEqual(expectedCg);
         simple.restore();
       });
+
+      test.each([
+        [[], '', false],
+        [[customerGroupA], customerGroupA.id, true],
+        [[customerGroupA, customerGroupB], '', false],
+      ])('setState is only called when expected', (uniqueCustomerGroups, callValue, isCallExpected) => {
+        const instanceA = getWrapper({ uniqueCustomerGroups }).instance();
+        const spy = jest.spyOn(instanceA, 'setState');
+        instanceA.componentDidMount();
+        expect(spy).toHaveBeenCalledTimes(isCallExpected ? 1 : 0);
+        if (isCallExpected) {
+          expect(spy).toHaveBeenCalledWith({
+            currentCustomerGroup: callValue,
+          });
+        }
+      });
     });
 
     test('calls handleSigninRefresh', () => {

--- a/app/pages/reservation/ReservationPage.spec.js
+++ b/app/pages/reservation/ReservationPage.spec.js
@@ -84,6 +84,7 @@ describe('pages/reservation/ReservationPage', () => {
     state: {},
     unit: Immutable(Unit.build()),
     user: Immutable(User.build()),
+    uniqueCustomerGroups: [],
   };
 
   function getWrapper(extraProps) {
@@ -227,6 +228,7 @@ describe('pages/reservation/ReservationPage', () => {
       expect(reservationProducts.prop('resource')).toBe(defaultProps.resource);
       expect(reservationProducts.prop('selectedTime')).toStrictEqual(expectedSelectedTime);
       expect(reservationProducts.prop('skipMandatoryProducts')).toBe(instance.state.skipMandatoryProducts);
+      expect(reservationProducts.prop('uniqueCustomerGroups')).toBe(defaultProps.uniqueCustomerGroups);
       expect(reservationProducts.prop('unit')).toBe(defaultProps.unit);
     });
   });
@@ -445,16 +447,27 @@ describe('pages/reservation/ReservationPage', () => {
         expect(instance.fetchResource.lastCall.args).toEqual([]);
       });
 
-      test('calls handleCheckOrderPrice', () => {
-        const { selected, reservationToEdit } = instance.props;
-        const { mandatoryProducts, extraProducts } = instance.state;
-        expect(instance.handleCheckOrderPrice.callCount).toBe(1);
-        expect(instance.handleCheckOrderPrice.lastCall.args[0]).toStrictEqual(resource);
-        expect(instance.handleCheckOrderPrice.lastCall.args[1]).toStrictEqual(selected);
-        expect(instance.handleCheckOrderPrice.lastCall.args[2]).toStrictEqual(mandatoryProducts);
-        expect(instance.handleCheckOrderPrice.lastCall.args[3]).toStrictEqual(extraProducts);
-        expect(instance.handleCheckOrderPrice.lastCall.args[4])
+      const customerGroupA = CustomerGroup.build();
+      const customerGroupB = CustomerGroup.build();
+      test.each([
+        [[], ''],
+        [[customerGroupA], customerGroupA.id],
+        [[customerGroupA, customerGroupB], ''],
+      ])('calls handleCheckOrderPrice, cgs: %p', (uniqueCustomerGroups, expectedCg) => {
+        const instanceA = getWrapper({ uniqueCustomerGroups }).instance();
+        instanceA.handleCheckOrderPrice = simple.mock();
+        instanceA.componentDidMount();
+        const { selected, reservationToEdit } = instanceA.props;
+        const { mandatoryProducts, extraProducts } = instanceA.state;
+        expect(instanceA.handleCheckOrderPrice.callCount).toBe(1);
+        expect(instanceA.handleCheckOrderPrice.lastCall.args[0]).toStrictEqual(resource);
+        expect(instanceA.handleCheckOrderPrice.lastCall.args[1]).toStrictEqual(selected);
+        expect(instanceA.handleCheckOrderPrice.lastCall.args[2]).toStrictEqual(mandatoryProducts);
+        expect(instanceA.handleCheckOrderPrice.lastCall.args[3]).toStrictEqual(extraProducts);
+        expect(instanceA.handleCheckOrderPrice.lastCall.args[4])
           .toStrictEqual(!isEmpty(reservationToEdit));
+        expect(instanceA.handleCheckOrderPrice.lastCall.args[5]).toStrictEqual(expectedCg);
+        simple.restore();
       });
     });
 
@@ -797,13 +810,31 @@ describe('pages/reservation/ReservationPage', () => {
   describe('handleProductsConfirm', () => {
     test('sets correct state when customer group is required and missing', () => {
       const cgA = CustomerGroup.build();
+      const cgB = CustomerGroup.build();
       const pcgA = ProductCustomerGroup.build({ customerGroup: cgA });
-      const prodA = Product.build({ productCustomerGroups: [pcgA] });
+      const pcgB = ProductCustomerGroup.build({ customerGroup: cgB });
+      const prodA = Product.build({ productCustomerGroups: [pcgA, pcgB] });
       const resourceA = Resource.build({ products: [prodA] });
-      const instance = getWrapper({ resource: resourceA }).instance();
+      const instance = getWrapper(
+        { resource: resourceA, uniqueCustomerGroups: [cgA, cgB] }
+      ).instance();
       instance.state.currentCustomerGroup = '';
       instance.handleProductsConfirm();
       expect(instance.state.customerGroupError).toBe(true);
+    });
+
+    test('sets correct state when there is only one unique customer group', () => {
+      const cgA = CustomerGroup.build();
+      const pcgA = ProductCustomerGroup.build({ customerGroup: cgA });
+      const prodA = Product.build({ productCustomerGroups: [pcgA] });
+      const resourceA = Resource.build({ products: [prodA] });
+      const instance = getWrapper(
+        { resource: resourceA, uniqueCustomerGroups: [cgA] }
+      ).instance();
+      instance.state.currentCustomerGroup = '';
+      instance.handleProductsConfirm();
+      expect(instance.state.currentCustomerGroup).toBe(cgA.id);
+      expect(instance.state.view).toBe('information');
     });
 
     test('sets correct state when there are no validation errors', () => {

--- a/app/pages/reservation/reservation-products/CustomerGroupNoOption.js
+++ b/app/pages/reservation/reservation-products/CustomerGroupNoOption.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import injectT from '../../../i18n/injectT';
+
+function CustomerGroupNoOption({ customerGroup, t }) {
+  return (
+    <div id="products-customer-group-no-option">
+      <p className="products-customer-group-no-option-label">
+        {t('ReservationProducts.select.clientGroup.label')}
+      </p>
+      <p className="products-customer-group-no-option-value">
+        {customerGroup.name}
+      </p>
+    </div>
+  );
+}
+
+CustomerGroupNoOption.propTypes = {
+  customerGroup: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
+};
+
+export default injectT(CustomerGroupNoOption);

--- a/app/pages/reservation/reservation-products/ReservationProducts.js
+++ b/app/pages/reservation/reservation-products/ReservationProducts.js
@@ -12,18 +12,20 @@ import ProductsSummary from './ProductsSummary';
 import ExtraProducts from './extra-products/ExtraProducts';
 import ReservationDetails from '../reservation-details/ReservationDetails';
 import CustomerGroupSelect from './CustomerGroupSelect';
-import { getProductsOfType, PRODUCT_TYPES, getUniqueCustomerGroups } from './ReservationProductsUtils';
+import {
+  getProductsOfType, PRODUCT_TYPES
+} from './ReservationProductsUtils';
 import ProductsValidationErrors from './ProductsValidationErrors';
 import PaymentMethodSelect from './PaymentMethodSelect';
+import CustomerGroupNoOption from './CustomerGroupNoOption';
 
 function ReservationProducts({
   changeProductQuantity, currentCustomerGroup, customerGroupError, currentPaymentMethod,
   currentLanguage, isEditing, isStaff, onBack, onCancel, onConfirm, onCustomerGroupChange,
   onPaymentMethodChange, onStaffSkipChange, order, resource, selectedTime,
-  skipMandatoryProducts, t, unit
+  skipMandatoryProducts, t, unit, uniqueCustomerGroups
 }) {
   const orderLines = order.order_lines || [];
-  const uniqueCustomerGroups = getUniqueCustomerGroups(resource);
   const mandatoryOrders = getProductsOfType(orderLines, PRODUCT_TYPES.MANDATORY);
   const extraOrders = getProductsOfType(orderLines, PRODUCT_TYPES.EXTRA);
 
@@ -39,7 +41,12 @@ function ReservationProducts({
         <Col lg={8} sm={12}>
           {!order.error ? (
             <Loader loaded={!order.loadingData}>
-              {uniqueCustomerGroups.length > 0 && (
+              {uniqueCustomerGroups.length === 1 && (
+                <CustomerGroupNoOption
+                  customerGroup={uniqueCustomerGroups[0]}
+                />
+              )}
+              {uniqueCustomerGroups.length > 1 && (
                 <CustomerGroupSelect
                   currentlySelectedGroup={currentCustomerGroup}
                   customerGroups={uniqueCustomerGroups}
@@ -136,6 +143,7 @@ ReservationProducts.propTypes = {
   skipMandatoryProducts: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,
   unit: PropTypes.object.isRequired,
+  uniqueCustomerGroups: PropTypes.array.isRequired,
 };
 
 export default injectT(ReservationProducts);

--- a/app/pages/reservation/reservation-products/ReservationProductsUtils.js
+++ b/app/pages/reservation/reservation-products/ReservationProductsUtils.js
@@ -138,6 +138,36 @@ export function getUniqueCustomerGroups(resource) {
 }
 
 /**
+ * Returns customer groups that are allowed for this user's login method.
+ * @param {array} customerGroups list of customer group objects
+ * @param {string} loginMethod e.g. user auth's amr value
+ * @returns {array} allowed customer group objects
+ */
+export function getAllowedCustomerGroups(customerGroups, loginMethod) {
+  const allowedCustomerGroups = [];
+  customerGroups.forEach((customerGroup) => {
+    if ('onlyForLoginMethods' in customerGroup) {
+      if (customerGroup.onlyForLoginMethods.length === 0) {
+        // cg has no restrictions, add it to allowed cgs
+        allowedCustomerGroups.push(customerGroup);
+      } else if (customerGroup.onlyForLoginMethods.length > 0) {
+        const loginMethodAllowed = customerGroup.onlyForLoginMethods.some(
+          allowedLoginMethod => allowedLoginMethod.loginMethodId === loginMethod
+        );
+        if (loginMethodAllowed) {
+          // cg has restrictions, but user's login method is allowed
+          allowedCustomerGroups.push(customerGroup);
+        }
+      }
+    } else {
+      // restrictions are missing, add cg to allowed cgs
+      allowedCustomerGroups.push(customerGroup);
+    }
+  });
+  return allowedCustomerGroups;
+}
+
+/**
  * Checks if a given customer group is found in given product customer groups
  * @param {string} customerGroup id
  * @param {Object[]} productCustomerGroups

--- a/app/pages/reservation/reservation-products/_reservation-products.scss
+++ b/app/pages/reservation/reservation-products/_reservation-products.scss
@@ -152,6 +152,16 @@
     font-weight: normal;
   }
 
+  #products-customer-group-no-option {
+    p {
+      margin-bottom: 0px;
+    }
+
+    .products-customer-group-no-option-label {
+      font-weight: bold;
+    }
+  }
+
   .has-error {
     color: $varaamo-high-contrast-red;
   }

--- a/app/pages/reservation/reservation-products/tests/CustomerGroupNoOption.spec.js
+++ b/app/pages/reservation/reservation-products/tests/CustomerGroupNoOption.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { shallowWithIntl } from 'utils/testUtils';
+import CustomerGroupNoOption from '../CustomerGroupNoOption';
+
+describe('reservation-products/CustomerGroupNoOption', () => {
+  const defaultProps = {
+    customerGroup: {
+      id: 'cg-1', name: 'Individuals'
+    }
+  };
+
+  function getWrapper(extraProps) {
+    return shallowWithIntl(<CustomerGroupNoOption {...defaultProps} {...extraProps} />);
+  }
+
+  describe('renders', () => {
+    test('wrapping div', () => {
+      const div = getWrapper().find('div#products-customer-group-no-option');
+      expect(div).toHaveLength(1);
+    });
+
+    test('label', () => {
+      const label = getWrapper().find('p.products-customer-group-no-option-label');
+      expect(label).toHaveLength(1);
+      expect(label.text()).toBe('ReservationProducts.select.clientGroup.label');
+    });
+
+    test('customer group name text', () => {
+      const cgName = getWrapper().find('p.products-customer-group-no-option-value');
+      expect(cgName).toHaveLength(1);
+      expect(cgName.text()).toBe(defaultProps.customerGroup.name);
+    });
+  });
+});

--- a/app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js
+++ b/app/pages/reservation/reservation-products/tests/ReservationProducts.spec.js
@@ -20,6 +20,7 @@ import CustomerGroup from 'utils/fixtures/CustomerGroup';
 import ProductsValidationErrors from '../ProductsValidationErrors';
 import PaymentMethodSelect from '../PaymentMethodSelect';
 import constants from '../../../../constants/AppConstants';
+import CustomerGroupNoOption from '../CustomerGroupNoOption';
 
 describe('reservation-products/ProductsSummary', () => {
   const resource = Immutable(Resource.build());
@@ -74,7 +75,8 @@ describe('reservation-products/ProductsSummary', () => {
       end: '2021-09-24T07:30:00.000Z',
     },
     skipMandatoryProducts: false,
-    unit: Unit.build()
+    unit: Unit.build(),
+    uniqueCustomerGroups: []
   };
 
   function getWrapper(extraProps) {
@@ -132,14 +134,40 @@ describe('reservation-products/ProductsSummary', () => {
           expect(select).toHaveLength(0);
         });
 
-        test('when there are unique customer groups in resource products', () => {
+        test('when there is only 1 unique customer group in resource products', () => {
+          const customerGroupA = CustomerGroup.build();
+          const pcgA = ProductCustomerGroup.build({ customerGroup: customerGroupA });
+          const productA = Product.build({ productCustomerGroups: [pcgA] });
+          const resourceA = Resource.build({ products: [productA] });
+          const wrapper = getWrapper({
+            resource: resourceA,
+            uniqueCustomerGroups: [customerGroupA]
+          });
+
+          const select = wrapper.find(CustomerGroupSelect);
+          expect(select).toHaveLength(0);
+
+          const noSelect = wrapper.find(CustomerGroupNoOption);
+          expect(noSelect).toHaveLength(1);
+          expect(noSelect.prop('customerGroup')).toBe(customerGroupA);
+        });
+
+        test('when there are more than 1 unique customer groups in resource products', () => {
           const customerGroupA = CustomerGroup.build();
           const customerGroupB = CustomerGroup.build();
           const pcgA = ProductCustomerGroup.build({ customerGroup: customerGroupA });
           const pcgB = ProductCustomerGroup.build({ customerGroup: customerGroupB });
           const productA = Product.build({ productCustomerGroups: [pcgA, pcgB] });
           const resourceA = Resource.build({ products: [productA] });
-          const select = getWrapper({ resource: resourceA }).find(CustomerGroupSelect);
+          const wrapper = getWrapper({
+            resource: resourceA,
+            uniqueCustomerGroups: [customerGroupA, customerGroupB]
+          });
+
+          const noSelect = wrapper.find(CustomerGroupNoOption);
+          expect(noSelect).toHaveLength(0);
+
+          const select = wrapper.find(CustomerGroupSelect);
           expect(select).toHaveLength(1);
           expect(select.prop('currentlySelectedGroup')).toBe(defaultProps.currentCustomerGroup);
           expect(select.prop('customerGroups')).toStrictEqual([customerGroupA, customerGroupB]);

--- a/app/pages/reservation/reservationPageSelector.js
+++ b/app/pages/reservation/reservationPageSelector.js
@@ -12,12 +12,15 @@ import {
   isAdminSelector,
   isLoggedInSelector,
   loginExpiresAtSelector,
+  authUserAmrSelector,
 } from 'state/selectors/authSelectors';
 import { createResourceSelector, unitsSelector } from 'state/selectors/dataSelectors';
 import dateSelector from 'state/selectors/dateSelector';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
 import { contrastSelector } from 'state/selectors/accessibilitySelectors';
 import { currentLanguageSelector } from 'state/selectors/translationSelectors';
+import { getAllowedCustomerGroups, getUniqueCustomerGroups } from './reservation-products/ReservationProductsUtils';
+import { hasProducts } from '../../utils/reservationUtils';
 
 const selectedSelector = state => orderBy(state.ui.reservations.selected, 'begin');
 const createdSelector = (state) => {
@@ -40,6 +43,19 @@ const unitSelector = createSelector(
   (resource, units) => units[resource.unit] || {}
 );
 
+const uniqueCustomerGroupsSelector = createSelector(
+  resourceSelector,
+  authUserAmrSelector,
+  (resource, loginMethod) => {
+    if (hasProducts(resource)) {
+      return getAllowedCustomerGroups(
+        getUniqueCustomerGroups(resource), loginMethod
+      );
+    }
+    return [];
+  }
+);
+
 const reservationPageSelector = createStructuredSelector({
   contrast: contrastSelector,
   currentLanguage: currentLanguageSelector,
@@ -58,6 +74,7 @@ const reservationPageSelector = createStructuredSelector({
   reservationCreated: createdSelector,
   reservationEdited: editedSelector,
   unit: unitSelector,
+  uniqueCustomerGroups: uniqueCustomerGroupsSelector,
   user: currentUserSelector,
 });
 

--- a/app/pages/reservation/reservationPageSelector.spec.js
+++ b/app/pages/reservation/reservationPageSelector.spec.js
@@ -185,6 +185,13 @@ describe('pages/reservation/reservationPageSelector', () => {
     expect(selected.unit).toEqual(defaultUnit);
   });
 
+  test('returns uniqueCustomerGroups', () => {
+    const state = getState();
+    const props = getProps();
+    const selected = reservationPageSelector(state, props);
+    expect(selected.uniqueCustomerGroups).toBeDefined();
+  });
+
   test('returns user', () => {
     const state = getState();
     const props = getProps();

--- a/app/state/selectors/authSelectors.js
+++ b/app/state/selectors/authSelectors.js
@@ -83,8 +83,19 @@ function createIsStaffSelector(resourceSelector) {
   );
 }
 
+const authUserAmrSelector = createSelector(
+  authUserSelector,
+  (user) => {
+    if (user && 'profile' in user && 'amr' in user.profile) {
+      return user.profile.amr;
+    }
+    return '';
+  }
+);
+
 export {
   authUserSelector,
+  authUserAmrSelector,
   createIsStaffSelector,
   currentUserSelector,
   isAdminSelector,

--- a/app/state/selectors/authSelectors.spec.js
+++ b/app/state/selectors/authSelectors.spec.js
@@ -11,6 +11,7 @@ import {
   staffUnitsSelector,
   loginExpiresAtSelector,
   hasStrongAuthSelector,
+  authUserAmrSelector,
 } from './authSelectors';
 
 describe('state/selectors/authSelectors', () => {
@@ -282,5 +283,20 @@ describe('state/selectors/authSelectors', () => {
         expect(selected).toEqual([]);
       }
     );
+  });
+
+  describe('authUserAmrSelector', () => {
+    test('returns user profile amr value if it exists', () => {
+      const amr = 'test-amr-1';
+      const user = { profile: { amr } };
+      const state = getState({ auth: { user } });
+      expect(authUserAmrSelector(state)).toEqual(amr);
+    });
+
+    test('returns empty string if amr value does not exist', () => {
+      const user = { profile: { } };
+      const state = getState({ auth: { user } });
+      expect(authUserAmrSelector(state)).toEqual('');
+    });
   });
 });


### PR DESCRIPTION
# Customer group login method restriction handling

## Changed restricted customer groups to be hidden from users in products page and when there is only one selectable customer group, it is shown as statement rather than a dropdown select

### [Related Trello card](https://trello.com/c/CeOPOX1E)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Reservation and products page
 1. app/pages/reservation/ReservationPage.js
     * Added `uniqueCustomerGroups` prop for the component
     * Added auto select handling for customer group when there is only one `uniqueCustomerGroups`
   
 2. app/pages/reservation/reservation-products/CustomerGroupNoOption.js
     * Added new component to show user's customer group when there is only one customer group to choose from
    
 3. app/pages/reservation/reservation-products/ReservationProducts.js
     * Added `uniqueCustomerGroups` prop for the component
     * Added logic to handle showing user customer group statement when there is only one customer group option

 3. app/pages/reservation/reservationPageSelector.js
     * Added selector for unique and non restricted customer group options
     
#### Utils
 1. app/pages/reservation/reservation-products/ReservationProductsUtils.js
     * Added function `getAllowedCustomerGroups` to filter restricted customer groups
   
 2. app/state/selectors/authSelectors.js
     * Added selector for getting user's amr value