### PR TITLE
Fixed null address text issue in resource page

### DIFF
--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -1,4 +1,3 @@
-import upperFirst from 'lodash/upperFirst';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Col from 'react-bootstrap/lib/Col';
@@ -9,6 +8,7 @@ import { injectT } from 'i18n';
 import WrappedText from 'shared/wrapped-text';
 import { getServiceMapUrl } from 'utils/unitUtils';
 import ReservationInfo from '../reservation-info';
+import ZipAndMunicipality from './ZipAndMunicipality';
 
 function ResourceInfo({
   addNotification, currentLanguage, isLoggedIn, isStrongAuthSatisfied, resource, unit, t, equipment
@@ -48,7 +48,7 @@ function ResourceInfo({
             <Col className="app-ResourceInfo__address" lg={6} md={6} sm={6} xs={12}>
               {unit && unit.name && <span>{unit.name}</span>}
               {unit && unit.streetAddress && <span>{unit.streetAddress}</span>}
-              {unit && <span>{`${unit.addressZip} ${upperFirst(unit.municipality)}`.trim()}</span>}
+              <ZipAndMunicipality unit={unit} />
             </Col>
             <Col className="app-ResourceInfo__web" lg={6} md={6} sm={6} xs={12}>
               {serviceMapUrl && (

--- a/app/pages/resource/resource-info/ResourceInfo.spec.js
+++ b/app/pages/resource/resource-info/ResourceInfo.spec.js
@@ -9,6 +9,7 @@ import { shallowWithIntl } from 'utils/testUtils';
 import { getServiceMapUrl } from 'utils/unitUtils';
 import ResourceInfo from './ResourceInfo';
 import ReservationInfo from '../reservation-info';
+import ZipAndMunicipality from './ZipAndMunicipality';
 
 describe('pages/resource/resource-info/ResourceInfo', () => {
   const defaultProps = {
@@ -115,10 +116,15 @@ describe('pages/resource/resource-info/ResourceInfo', () => {
       .find('.app-ResourceInfo__address')
       .find('span');
 
-    expect(addressSpan).toHaveLength(3);
+    expect(addressSpan).toHaveLength(2);
     expect(addressSpan.at(0).text()).toBe(unit.name);
     expect(addressSpan.at(1).text()).toBe(unit.streetAddress);
-    expect(addressSpan.at(2).text()).toBe('99999 Helsinki');
+  });
+
+  test('renders ZipAndMunicipality', () => {
+    const zipAndMunicipality = getWrapper().find(ZipAndMunicipality);
+    expect(zipAndMunicipality).toHaveLength(1);
+    expect(zipAndMunicipality.prop('unit')).toBe(defaultProps.unit);
   });
 
   test('renders web address', () => {

--- a/app/pages/resource/resource-info/ZipAndMunicipality.js
+++ b/app/pages/resource/resource-info/ZipAndMunicipality.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import upperFirst from 'lodash/upperFirst';
+
+function ZipAndMunicipality({ unit }) {
+  const addressZip = unit && unit.addressZip ? unit.addressZip : '';
+  const municipality = unit && unit.municipality ? upperFirst(unit.municipality) : '';
+
+  if (!unit || (!addressZip && !municipality)) {
+    return null;
+  }
+
+  return (
+    <span>{`${addressZip} ${municipality}`.trim()}</span>
+  );
+}
+
+ZipAndMunicipality.defaultProps = {
+  unit: undefined
+};
+
+ZipAndMunicipality.propTypes = {
+  unit: PropTypes.object
+};
+
+export default ZipAndMunicipality;

--- a/app/pages/resource/resource-info/ZipAndMunicipality.spec.js
+++ b/app/pages/resource/resource-info/ZipAndMunicipality.spec.js
@@ -1,0 +1,44 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Unit from '../../../utils/fixtures/Unit';
+import ZipAndMunicipality from './ZipAndMunicipality';
+
+describe('pages/resource/resource-info/ZipAndMunicipality', () => {
+  const defaultProps = {
+    unit: Unit.build()
+  };
+
+  function getWrapper(extraProps) {
+    return shallow(<ZipAndMunicipality {...defaultProps} {...extraProps} />);
+  }
+
+  describe('renders', () => {
+    describe('null', () => {
+      test('when unit is falsy', () => {
+        const component = getWrapper({ unit: undefined });
+        expect(component.isEmptyRender()).toBe(true);
+      });
+
+      test('when unit exists but its zip and municipality are falsy', () => {
+        const unit = Unit.build({ addressZip: null, municipality: null });
+        const component = getWrapper({ unit });
+        expect(component.isEmptyRender()).toBe(true);
+      });
+    });
+
+    describe('correct span text', () => {
+      test.each([
+        [123456, null, '123456'],
+        [null, 'turku', 'Turku'],
+        [123456, 'turku', '123456 Turku'],
+      ])('when zip is %p and municipality is %p', (addressZip, municipality, expected) => {
+        const unit = Unit.build({ addressZip, municipality });
+        const wrapper = getWrapper({ unit });
+        const span = wrapper.find('span');
+        expect(span).toHaveLength(1);
+        expect(span.text()).toBe(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Fixed null address text issue in resource page

## Refactored Resource page unit address zip and municipality rendering and fixed a potential address value from being displayed as null to users

### [Related Trello card](https://trello.com/c/ZEONUuFa)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Resource page unit address refactor and fix
 1. app/pages/resource/resource-info/ResourceInfo.js
     * Moved unit zip and municipality to its own component
   
 2. app/pages/resource/resource-info/ZipAndMunicipality.spec.js
     * New component to render unit zip and municipality info