### PR TITLE
Changed staff event checkbox field to be hidden

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -24,7 +24,6 @@ class ReservationInformation extends Component {
     isAdmin: PropTypes.bool.isRequired,
     isEditing: PropTypes.bool.isRequired,
     isMakingReservations: PropTypes.bool.isRequired,
-    isStaff: PropTypes.bool.isRequired,
     onBack: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
@@ -47,7 +46,6 @@ class ReservationInformation extends Component {
   getFormFields = (termsAndConditions) => {
     const {
       isAdmin,
-      isStaff,
       resource,
       order,
       reservation,
@@ -77,9 +75,11 @@ class ReservationInformation extends Component {
       // formFields.push('reserverPhoneNumber');
     }
 
+    /* Field hidden until it is needed again
     if (resource.needManualConfirmation && isStaff) {
       formFields.push('staffEvent');
     }
+    */
 
     if (termsAndConditions) {
       formFields.push('termsAndConditions');

--- a/app/pages/reservation/reservation-information/ReservationInformation.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.spec.js
@@ -164,8 +164,10 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
       }
     );
 
+    /* Field staffEvent hidden until it is needed again
     test(
-      'returns supportedReservationExtraFields and staffEvent when needManualConfirmation and is staff',
+      'returns supportedReservationExtraFields and staffEvent when
+       needManualConfirmation and is staff',
       () => {
         const wrapper = getWrapper({ isStaff: true, resource });
         const instance = wrapper.instance();
@@ -174,6 +176,7 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
         expect(actual).toEqual([...supportedFields, 'staffEvent']);
       }
     );
+    */
 
     test('returns supportedReservationExtraFields and termsAndConditions', () => {
       const termsAndConditions = 'some terms and conditions';

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.js
@@ -61,9 +61,11 @@ class ConfirmReservationModal extends Component {
       formFields.push('reserverPhoneNumber');
     }
 
+    /* Field hidden until it is needed again
     if (resource.needManualConfirmation && isStaff) {
       formFields.push('staffEvent');
     }
+    */
 
     if (termsAndConditions) {
       formFields.push('termsAndConditions');

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
@@ -179,6 +179,7 @@ describe('shared/reservation-confirmation/ConfirmReservationModal', () => {
       });
     });
 
+    /* Field hidden until it is needed again
     describe('staffEvent', () => {
       test('is not included if resource does not need manual confirmation', () => {
         const props = {
@@ -207,6 +208,7 @@ describe('shared/reservation-confirmation/ConfirmReservationModal', () => {
         }
       );
     });
+    */
 
     describe('termsAndConditions', () => {
       test('is included if resource contains terms', () => {


### PR DESCRIPTION
# Staff event checkbox field removal from use

## Staff event field is not currently needed and can even cause issues with paid reservations in its current state, so it is hidden for now

### [Related Trello card](https://trello.com/c/hI1tp2gU)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Staff event field hiding
 1. app/pages/reservation/reservation-information/ReservationInformation.js
     * commented out staff event field and removed not needed `isStaff` prop
   
 2. app/shared/reservation-confirmation/ConfirmReservationModal.js
     * commented out staff event field
