### PR TITLE
Updated github action tests to use ubuntu 20

### DIFF
--- a/.github/workflows/varaamo.yml
+++ b/.github/workflows/varaamo.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION
# GitHub action test ubuntu version

Updated tests to use ubuntu v20 instead of v18