### PR TITLE
Added help text for reservation email and phone

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -58,6 +58,7 @@
   "common.companyLabel": "Company",
   "common.confirmCashPayment": "Approve cash payment",
   "common.confirmed": "Approved",
+  "common.contactPurposeHelp": "Contact information can be used to contact you",
   "common.continue": "Continue",
   "common.denied": "Denied",
   "common.eventDescriptionLabel": "Description of the event",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -58,6 +58,7 @@
   "common.companyLabel": "Yritys",
   "common.confirmCashPayment": "Hyväksy käteismaksu",
   "common.confirmed": "Hyväksytty",
+  "common.contactPurposeHelp": "Yhteystietoa voidaan käyttää yhteydenottoa varten",
   "common.continue": "Jatka",
   "common.denied": "Hylätty",
   "common.eventDescriptionLabel": "Tilaisuuden kuvaus",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -58,6 +58,7 @@
   "common.companyLabel": "Företag",
   "common.confirmCashPayment": "Godkänn kontant betalning",
   "common.confirmed": "Godkänd",
+  "common.contactPurposeHelp": "kontaktuppgifterna kan användas för att kontakta dig",
   "common.continue": "Fortsätt",
   "common.denied": "Ej godkänd",
   "common.eventDescriptionLabel": "Beskrivning av evenemanget",

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -309,14 +309,16 @@ class UnconnectedReservationInformationForm extends Component {
             'phone',
             'text',
             t('common.reserverPhoneNumberLabel'),
-            { autoComplete: 'tel' }
+            { autoComplete: 'tel' },
+            t('common.contactPurposeHelp'),
           )}
           {this.renderField(
             'reserverEmailAddress',
             'email',
             'email',
             t('common.reserverEmailAddressLabel'),
-            { autoComplete: 'email' }
+            { autoComplete: 'email' },
+            t('common.contactPurposeHelp'),
           )}
           {resource.universalField && resource.universalField.length > 0
             && this.renderUniversalFields()


### PR DESCRIPTION
# Purpose help text for reservation form email and phone fields

[Related Trello card](https://trello.com/c/v28DwnNO)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Purpose help texts
 1. app/pages/reservation/reservation-information/ReservationInformationForm.js
     * added purpose help texts for email and phone