### PR TITLE
Added setting for blocking search engine indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ By default the running app can be found at `localhost:3000`.
       Custom config to override global application's styling and texts.
       Expected value is a valid string that is the name of the theme package, e.g. `THEME_PMG='varaamo-theme'`. Default styles and texts will be used if not set.
 
+    - `BLOCK_SEARCH_ENGINE_INDEXING`:
+      Adding this setting prevents most search engines from indexing the site. This can be useful for preventing test instances from showing up in search results.
+
 
 3. Then, start the development server:
 

--- a/config/webpack.development.js
+++ b/config/webpack.development.js
@@ -76,6 +76,7 @@ module.exports = merge(common, {
         OG_IMG_URL: JSON.stringify(process.env.OG_IMG_URL || 'https://testivaraamo.turku.fi/static/images/aurajoki.jpg'),
         COOKIE_POLICY_BASE_URL: JSON.stringify(process.env.COOKIE_POLICY_BASE_URL || 'https://testivaraamo.turku.fi/cookie-policy/'),
         THEME_PKG: JSON.stringify(process.env.THEME_PKG),
+        BLOCK_SEARCH_ENGINE_INDEXING: Boolean(process.env.BLOCK_SEARCH_ENGINE_INDEXING),
       },
     }),
     new webpack.HotModuleReplacementPlugin(),

--- a/config/webpack.production.js
+++ b/config/webpack.production.js
@@ -66,6 +66,7 @@ module.exports = merge(common, {
         OPENID_AUTHORITY: JSON.stringify(process.env.OPENID_AUTHORITY),
         OG_IMG_URL: JSON.stringify(process.env.OG_IMG_URL || 'https://varaamo.turku.fi/static/images/aurajoki.jpg'),
         COOKIE_POLICY_BASE_URL: JSON.stringify(process.env.COOKIE_POLICY_BASE_URL || 'https://varaamo.turku.fi/cookie-policy/'),
+        BLOCK_SEARCH_ENGINE_INDEXING: Boolean(process.env.BLOCK_SEARCH_ENGINE_INDEXING),
       },
     }),
     new MiniCssExtractPlugin({

--- a/server/Html.js
+++ b/server/Html.js
@@ -95,6 +95,9 @@ class Html extends Component {
           <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,800" rel="stylesheet" />
           {this.getConsentScripts()}
           {Boolean(process.env.MATOMO_SITE_ID) && <script dangerouslySetInnerHTML={{ __html: this.getCookieScript() }} type="text/javascript" />}
+          {Boolean(process.env.BLOCK_SEARCH_ENGINE_INDEXING) && (
+            <meta content="noindex, nofollow" name="robots" />
+          )}
           {this.renderStylesLink(appCssSrc, isProduction)}
           <title>Varaamo</title>
         </head>


### PR DESCRIPTION
# Setting for blocking search engine indexing

## Env setting `BLOCK_SEARCH_ENGINE_INDEXING` adds html head meta tag to block search engine indexing

### [Related Trello card](https://trello.com/c/nFlEr8mz)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### env setting
 1. config/webpack.development.js
 2. config/webpack.production.js
 3. server/Html.js
     * Added `BLOCK_SEARCH_ENGINE_INDEXING` setting which adds the html tag `<meta content="noindex, nofollow" name="robots" />`