### PR TITLE
Staff can make reservations for customers to external resources

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -30,6 +30,8 @@
   "AdminResourcesPage.noRightsMessage": "Official rights are required to see this page.",
   "AdminResourcesPage.adminTitle": "My premises",
   "AdminResourcesPage.favoriteTitle": "My favorites",
+  "AdminResourcesPage.external.toggle": "External resources",
+  "AdminResourcesPage.external.label": "External",
   "AvailabilityViewDateSelector.nextDay": "next day",
   "AvailabilityViewDateSelector.previousDay": "previous day",
   "CommentForm.label": "Comments:",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -30,6 +30,8 @@
   "AdminResourcesPage.noRightsMessage": "Tarvitset virkailijan oikeudet nähdäksesi tämän sivun.",
   "AdminResourcesPage.adminTitle": "Omat tilat",
   "AdminResourcesPage.favoriteTitle": "Suosikit",
+  "AdminResourcesPage.external.toggle": "Ulkoiset tilat",
+  "AdminResourcesPage.external.label": "Ulkoinen",
   "AvailabilityViewDateSelector.nextDay": "seuraava päivä",
   "AvailabilityViewDateSelector.previousDay": "edellinen päivä",
   "CommentForm.label": "Kommentit:",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -30,6 +30,8 @@
   "AdminResourcesPage.noRightsMessage": "För att visa den här sidan krävs tjänstemannabehörighet.",
   "AdminResourcesPage.adminTitle": "Egna utrymmen",
   "AdminResourcesPage.favoriteTitle": "Egna favoriter",
+  "AdminResourcesPage.external.toggle": "Externa utrymmen",
+  "AdminResourcesPage.external.label": "Extern",
   "AvailabilityViewDateSelector.nextDay": "följande dag",
   "AvailabilityViewDateSelector.previousDay": "föregående dag",
   "CommentForm.label": "Kommentarer:",

--- a/app/pages/admin-resources/AdminResourcesPage.js
+++ b/app/pages/admin-resources/AdminResourcesPage.js
@@ -25,7 +25,7 @@ import adminResourcesPageSelector from './adminResourcesPageSelector';
 class UnconnectedAdminResourcesPage extends Component {
   constructor(props) {
     super(props);
-    this.state = { selection: null };
+    this.state = { selection: null, showExternalResources: false };
     this.fetchResources = this.fetchResources.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
   }
@@ -66,16 +66,26 @@ class UnconnectedAdminResourcesPage extends Component {
     this.props.actions.openConfirmReservationModal();
   }
 
+  toggleShowExternalResources = () => {
+    this.setState(prevState => ({ showExternalResources: !prevState.showExternalResources }));
+  }
+
   render() {
     const {
       selectedResourceTypes,
       isAdmin,
       isLoggedin,
       isFetchingResources,
-      resources,
+      resources: rawResources,
       t,
       resourceTypes,
+      externalResources,
     } = this.props;
+    const { showExternalResources } = this.state;
+    let resources = rawResources;
+    if (showExternalResources) {
+      resources = resources.concat(externalResources.map(res => res.id));
+    }
     return (
       <PageWrapper className="admin-resources-page" fluid title={(t('AdminResourcesPage.adminTitle'))}>
         {isAdmin && <h1>{t('AdminResourcesPage.adminTitle')}</h1>}
@@ -84,10 +94,13 @@ class UnconnectedAdminResourcesPage extends Component {
           {isLoggedin && (
             <div>
               <ResourceTypeFilter
+                externalResources={externalResources}
                 onSelectResourceType={this.props.actions.selectAdminResourceType}
                 onUnselectResourceType={this.props.actions.unselectAdminResourceType}
                 resourceTypes={resourceTypes}
                 selectedResourceTypes={selectedResourceTypes}
+                showExternalResources={showExternalResources}
+                toggleShowExternalResources={this.toggleShowExternalResources}
               />
               <AvailabilityView
                 date={this.props.date}
@@ -130,6 +143,7 @@ UnconnectedAdminResourcesPage.propTypes = {
   resources: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
   resourceTypes: PropTypes.array.isRequired,
+  externalResources: PropTypes.array,
 };
 
 UnconnectedAdminResourcesPage = injectT(UnconnectedAdminResourcesPage);  // eslint-disable-line

--- a/app/pages/admin-resources/AdminResourcesPage.spec.js
+++ b/app/pages/admin-resources/AdminResourcesPage.spec.js
@@ -36,6 +36,7 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
     location: { id: '123' },
     resources: [],
     resourceTypes: ['a', 'b', 'c'],
+    externalResources: [],
   };
 
   function getWrapper(extraProps = {}) {
@@ -94,28 +95,72 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
           expect(loader.prop('loaded')).toBe(true);
         });
       });
-
-      test('renders AvailabilityView with correct props', () => {
-        const resources = [{ foo: 'bar' }];
-        const wrapper = getIsAdminWrapper({ resources });
-        const view = wrapper.find(AvailabilityView);
-        expect(view).toHaveLength(1);
-        expect(view.prop('groups')).toEqual([
-          { name: '', resources },
-        ]);
-        expect(view.prop('date')).toEqual('2017-01-10');
-        expect(view.prop('onDateChange')).toBe(changeAdminResourcesPageDate);
-        expect(view.prop('onSelect')).toBe(wrapper.instance().handleSelect);
+      describe('AvailabilityView', () => {
+        test('renders with correct props', () => {
+          const resources = ['resourceID01'];
+          const wrapper = getIsAdminWrapper({ resources });
+          const view = wrapper.find(AvailabilityView);
+          expect(view).toHaveLength(1);
+          expect(view.prop('groups')).toEqual([
+            { name: '', resources },
+          ]);
+          expect(view.prop('date')).toEqual('2017-01-10');
+          expect(view.prop('onDateChange')).toBe(changeAdminResourcesPageDate);
+          expect(view.prop('onSelect')).toBe(wrapper.instance().handleSelect);
+        });
+        test('renders with correct props when state.showExternalResources is true', () => {
+          const resources = ['firstID'];
+          const externalResources = [{ id: 'viewerOnlyID1' }, { id: 'viewerOnlyID2' }];
+          const wrapper = getIsAdminWrapper({ resources, externalResources });
+          const instance = wrapper.instance();
+          let view = wrapper.find(AvailabilityView);
+          expect(view).toHaveLength(1);
+          expect(view.prop('groups')).toEqual([
+            { name: '', resources },
+          ]);
+          expect(view.prop('date')).toEqual('2017-01-10');
+          expect(view.prop('onDateChange')).toBe(changeAdminResourcesPageDate);
+          expect(view.prop('onSelect')).toBe(wrapper.instance().handleSelect);
+          instance.toggleShowExternalResources();
+          view = wrapper.find(AvailabilityView);
+          expect(view).toHaveLength(1);
+          expect(view.prop('groups')).toEqual([
+            { name: '', resources: [...resources, ...externalResources.map(res => res.id)] },
+          ]);
+          expect(view.prop('date')).toEqual('2017-01-10');
+          expect(view.prop('onDateChange')).toBe(changeAdminResourcesPageDate);
+          expect(view.prop('onSelect')).toBe(wrapper.instance().handleSelect);
+        });
       });
 
-      test('renders ResourceTypeFilter with correct props', () => {
-        const wrapper = getIsAdminWrapper();
-        const resourceTypeFilter = wrapper.find(ResourceTypeFilter);
-        expect(resourceTypeFilter).toHaveLength(1);
-        expect(resourceTypeFilter.prop('selectedResourceTypes')).toEqual(defaultProps.selectedResourceTypes);
-        expect(resourceTypeFilter.prop('resourceTypes')).toEqual(defaultProps.resourceTypes);
-        expect(resourceTypeFilter.prop('onSelectResourceType')).toBe(selectAdminResourceType);
-        expect(resourceTypeFilter.prop('onUnselectResourceType')).toBe(unselectAdminResourceType);
+      describe('ResourceTypeFilter', () => {
+        test('renders with correct default props', () => {
+          const wrapper = getIsAdminWrapper();
+          const resourceTypeFilter = wrapper.find(ResourceTypeFilter);
+          expect(resourceTypeFilter).toHaveLength(1);
+          expect(resourceTypeFilter.prop('selectedResourceTypes')).toEqual(defaultProps.selectedResourceTypes);
+          expect(resourceTypeFilter.prop('resourceTypes')).toEqual(defaultProps.resourceTypes);
+          expect(resourceTypeFilter.prop('onSelectResourceType')).toBe(selectAdminResourceType);
+          expect(resourceTypeFilter.prop('onUnselectResourceType')).toBe(unselectAdminResourceType);
+          expect(resourceTypeFilter.prop('toggleShowExternalResources')).toBe(wrapper.instance().toggleShowExternalResources);
+          expect(resourceTypeFilter.prop('externalResources')).toBe(defaultProps.externalResources);
+          expect(resourceTypeFilter.prop('showExternalResources')).toBe(false);
+        });
+        test('renders with correct props when state.showExternalResources is true', () => {
+          const externalResources = [{ id: 'viewerOnlyID1' }, { id: 'viewerOnlyID2' }];
+          const wrapper = getIsAdminWrapper({ externalResources });
+          const instance = wrapper.instance();
+          instance.toggleShowExternalResources();
+          const resourceTypeFilter = wrapper.find(ResourceTypeFilter);
+          expect(resourceTypeFilter).toHaveLength(1);
+          expect(resourceTypeFilter.prop('selectedResourceTypes')).toEqual(defaultProps.selectedResourceTypes);
+          expect(resourceTypeFilter.prop('resourceTypes')).toEqual(defaultProps.resourceTypes);
+          expect(resourceTypeFilter.prop('onSelectResourceType')).toBe(selectAdminResourceType);
+          expect(resourceTypeFilter.prop('onUnselectResourceType')).toBe(unselectAdminResourceType);
+          expect(resourceTypeFilter.prop('toggleShowExternalResources')).toBe(instance.toggleShowExternalResources);
+          expect(resourceTypeFilter.prop('externalResources')).toBe(externalResources);
+          expect(resourceTypeFilter.prop('showExternalResources')).toBe(true);
+        });
       });
     });
   });
@@ -298,7 +343,7 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
       const wrapper = getWrapper();
       const selection = { some: 'data' };
       wrapper.instance().handleSelect(selection);
-      expect(wrapper.state()).toEqual({ selection });
+      expect(wrapper.state('selection')).toEqual(selection);
     });
 
     test('calls changeRecurringBaseTime with correct time', () => {

--- a/app/pages/admin-resources/adminResourcesPageSelector.js
+++ b/app/pages/admin-resources/adminResourcesPageSelector.js
@@ -83,6 +83,21 @@ const filteredAdminResourceSelector = createSelector(
   )
 );
 
+// resources in which the user can make reservations for a customer but isn't staff.
+const externalResourcesSelector = createSelector(
+  adminResourcesSelectors,
+  filteredAdminResourceSelector,
+  (resources, filteredResources) => resources.filter(
+    resource => (
+      resource.userPermissions.canMakeReservationsForCustomer
+      && !filteredResources.includes(resource))
+  )
+);
+
+const filteredExternalResourcesSelector = createSelector(
+  externalResourcesSelector,
+  resources => sortBy(resources, 'name').map(res => ({ id: res.id, name: res.name }))
+);
 const filteredAdminResourcesIdsSelector = createSelector(
   filteredAdminResourceSelector,
   resources => sortBy(resources, 'name').map(res => res.id),
@@ -98,6 +113,7 @@ const adminResourcesPageSelector = createStructuredSelector({
   isFetchingResources: requestIsActiveSelectorFactory(ActionTypes.API.RESOURCES_GET_REQUEST),
   resources: filteredAdminResourcesIdsSelector,
   resourceTypes: adminResourceTypesSelector,
+  externalResources: filteredExternalResourcesSelector,
 });
 
 export default adminResourcesPageSelector;

--- a/app/pages/admin-resources/adminResourcesPageSelector.spec.js
+++ b/app/pages/admin-resources/adminResourcesPageSelector.spec.js
@@ -44,6 +44,16 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
     };
   }
 
+  const resourceGenerator = (id, name, type, unit, canMakeReservationsForCustomer = false) => (
+    {
+      id,
+      name: { fi: name },
+      type: { name: type },
+      unit,
+      userPermissions: { canMakeReservationsForCustomer }
+    }
+  );
+
   test('returns isAdmin', () => {
     expect(getSelected().isAdmin).toBeDefined();
   });
@@ -68,6 +78,10 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
     expect(getSelected().resourceTypes).toBeDefined();
   });
 
+  test('returns externalResources', () => {
+    expect(getSelected().externalResources).toBeDefined();
+  });
+
   test('returns date', () => {
     const selected = getSelected({ 'ui.pages.adminResources': { date: '2017-02-01' } });
     expect(selected.date).toBe('2017-02-01');
@@ -79,15 +93,9 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   });
 
   test('returns an array of resource ids ordered by translated name', () => {
-    const resource1 = {
-      id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-    };
-    const resource2 = {
-      id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID01'
-    };
-    const resource3 = {
-      id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
-    };
+    const resource1 = resourceGenerator(1, 'Tatooine', 'school', 'unitID01');
+    const resource2 = resourceGenerator(2, 'Dantooine', 'library', 'unitID01');
+    const resource3 = resourceGenerator(3, 'Alderaan', 'printer', 'unitID01');
     const extraState = {
       'data.resources': {
         [resource1.id]: resource1,
@@ -103,12 +111,8 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   });
 
   test('returns an empty array if user doesnt have manager rights for anything', () => {
-    const resource1 = {
-      id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-    };
-    const resource2 = {
-      id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
-    };
+    const resource1 = resourceGenerator('resourceID01', 'Tatooine', 'school', 'unitID01');
+    const resource2 = resourceGenerator('resourceID02', 'Dantooine', 'library', 'unitID02');
     const extraState = {
       'data.users.2019token.staffStatus': {},
       'data.resources': {
@@ -123,18 +127,10 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   });
 
   test('return an array of all resources from all units if the user isSuperUser', () => {
-    const resource1 = {
-      id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'room' }, unit: 'unitID01'
-    };
-    const resource2 = {
-      id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'space' }, unit: 'unitID02'
-    };
-    const resource3 = {
-      id: 'resourceID03', name: { fi: 'Dagobah' }, type: { name: 'work' }, unit: 'unitID03'
-    };
-    const resource4 = {
-      id: 'resourceID04', name: { fi: 'Hoth' }, type: { name: 'library' }, unit: 'unitID04'
-    };
+    const resource1 = resourceGenerator('resourceID01', 'Tatooine', 'room', 'unitID01');
+    const resource2 = resourceGenerator('resourceID02', 'Dantooine', 'space', 'unitID02');
+    const resource3 = resourceGenerator('resourceID03', 'Dagobah', 'work', 'unitID03');
+    const resource4 = resourceGenerator('resourceID04', 'Hoth', 'library', 'unitID04');
     const extraState = {
       'data.resources': {
         [resource1.id]: resource1,
@@ -159,18 +155,10 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   test(
     'returns array of resource ids consisting of resources that are in a unit where user is a unit manager',
     () => {
-      const resource1 = {
-        id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-      };
-      const resource2 = {
-        id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
-      };
-      const resource3 = {
-        id: 'resourceID03', name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
-      };
-      const resource4 = {
-        id: 'resourceID04', name: { fi: 'Dagobah' }, type: { name: 'printer' }, unit: 'unitID02'
-      };
+      const resource1 = resourceGenerator('resourceID01', 'Tatooine', 'school', 'unitID01');
+      const resource2 = resourceGenerator('resourceID02', 'Dantooine', 'library', 'unitID02');
+      const resource3 = resourceGenerator('resourceID03', 'Alderaan', 'printer', 'unitID01');
+      const resource4 = resourceGenerator('resourceID04', 'Dagobah', 'printer', 'unitID02');
 
       const extraState = {
         'data.resources': {
@@ -190,21 +178,11 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   test(
     'returns array of resource ids consisting of resources that are in various units when user is a unit group admin',
     () => {
-      const resource1 = {
-        id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-      };
-      const resource2 = {
-        id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
-      };
-      const resource3 = {
-        id: 'resourceID03', name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
-      };
-      const resource4 = {
-        id: 'resourceID04', name: { fi: 'Dagobah' }, type: { name: 'printer' }, unit: 'unitID02'
-      };
-      const resource5 = {
-        id: 'resourceID05', name: { fi: 'Hoth' }, type: { name: 'workspace' }, unit: 'unitID03'
-      };
+      const resource1 = resourceGenerator('resourceID01', 'Tatooine', 'school', 'unitID01');
+      const resource2 = resourceGenerator('resourceID02', 'Dantooine', 'library', 'unitID02');
+      const resource3 = resourceGenerator('resourceID03', 'Alderaan', 'printer', 'unitID01');
+      const resource4 = resourceGenerator('resourceID04', 'Dagobah', 'printer', 'unitID02');
+      const resource5 = resourceGenerator('resourceID05', 'Hoth', 'workspace', 'unitID03');
 
       const extraState = {
         'data.resources': {
@@ -224,12 +202,8 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   );
 
   test('returns only resources which are found with ids in admin resources id array', () => {
-    const resource1 = {
-      id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-    };
-    const resource2 = {
-      id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
-    };
+    const resource1 = resourceGenerator('resourceID01', 'Tatooine', 'school', 'unitID01');
+    const resource2 = resourceGenerator('resourceID02', 'Dantooine', 'library', 'unitID02');
 
     const extraState = {
       'data.resources': {
@@ -246,15 +220,9 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   });
 
   test('returns an array of resourceTypes', () => {
-    const resource1 = {
-      id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-    };
-    const resource2 = {
-      id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID01'
-    };
-    const resource3 = {
-      id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
-    };
+    const resource1 = resourceGenerator(1, 'Tatooine', 'school', 'unitID01');
+    const resource2 = resourceGenerator(2, 'Dantooine', 'library', 'unitID01');
+    const resource3 = resourceGenerator(3, 'Alderaan', 'printer', 'unitID01');
     const extraState = {
       'data.resources': {
         [resource1.id]: resource1,
@@ -269,18 +237,10 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   });
 
   test('returns an array of resourceTypes according to user staff permissions', () => {
-    const resource1 = {
-      id: 'resourceID01', name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-    };
-    const resource2 = {
-      id: 'resourceID02', name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID02'
-    };
-    const resource3 = {
-      id: 'resourceID03', name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
-    };
-    const resource4 = {
-      id: 'resourceID04', name: { fi: 'Dagobah' }, type: { name: 'studio' }, unit: 'unitID01'
-    };
+    const resource1 = resourceGenerator('resourceID01', 'Tatooine', 'school', 'unitID01');
+    const resource2 = resourceGenerator('resourceID02', 'Dantooine', 'library', 'unitID02');
+    const resource3 = resourceGenerator('resourceID03', 'Alderaan', 'printer', 'unitID01');
+    const resource4 = resourceGenerator('resourceID04', 'Dagobah', 'studio', 'unitID01');
 
     const extraState = {
       'data.resources': {
@@ -300,15 +260,9 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
   test(
     'returns an array of selectedResourceTypes and filtered resourceIds',
     () => {
-      const resource1 = {
-        id: 1, name: { fi: 'Tatooine' }, type: { name: 'school' }, unit: 'unitID01'
-      };
-      const resource2 = {
-        id: 2, name: { fi: 'Dantooine' }, type: { name: 'library' }, unit: 'unitID01'
-      };
-      const resource3 = {
-        id: 3, name: { fi: 'Alderaan' }, type: { name: 'printer' }, unit: 'unitID01'
-      };
+      const resource1 = resourceGenerator(1, 'Tatooine', 'school', 'unitID01');
+      const resource2 = resourceGenerator(2, 'Dantooine', 'library', 'unitID01');
+      const resource3 = resourceGenerator(3, 'Alderaan', 'printer', 'unitID01');
       const extraState = {
         'data.resources': {
           [resource1.id]: resource1,
@@ -323,4 +277,31 @@ describe('pages/admin-resources/adminResourcesPageSelector', () => {
       expect(selected.resources).toEqual([1]);
     }
   );
+  test('externalResources is an array consisting of external resources', () => {
+    // resources that the user can create reservations for even if they aren't staff for that unit.
+    const resource1 = resourceGenerator(1, 'Room 1', 'work', 'unit01', false);
+    const resource2 = resourceGenerator(2, 'Room 2', 'work', 'unit01', false);
+    const resource3 = resourceGenerator(3, 'Room 3', 'work', 'unit01', false);
+    const resource4 = resourceGenerator(4, 'IT Help 1', 'guidance', 'unit33', true);
+    const resource5 = resourceGenerator(5, 'IT Help 2', 'guidance', 'unit33', true);
+
+    const extraState = {
+      'data.resources': {
+        [resource1.id]: resource1,
+        [resource2.id]: resource2,
+        [resource3.id]: resource3,
+        [resource4.id]: resource4,
+        [resource5.id]: resource5
+      },
+      'intl.locale': 'fi',
+      'ui.pages.adminResources.resourceIds': [resource1.id, resource2.id, resource3.id, resource4.id, resource5.id],
+      'data.users.2019token.staffStatus.isManagerFor': ['unit01']
+    };
+    // should only contain resources that the user doesn't have any 'staff' rights to.
+    const expected = [
+      { id: resource4.id, name: resource4.name.fi }, { id: resource5.id, name: resource5.name.fi }
+    ];
+    const selected = getSelected(extraState);
+    expect(selected.externalResources).toEqual(expected);
+  });
 });

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -10,7 +10,7 @@ import isEmail from 'validator/lib/isEmail';
 
 import FormTypes from 'constants/FormTypes';
 import constants from 'constants/AppConstants';
-import { isValidPhoneNumber, hasProducts } from 'utils/reservationUtils';
+import { isValidPhoneNumber, hasProducts, normalizeUniversalFieldOptions } from 'utils/reservationUtils';
 import ReduxFormField from 'shared/form-fields/ReduxFormField';
 import TermsField from 'shared/form-fields/TermsField';
 import { injectT } from 'i18n';
@@ -210,39 +210,18 @@ class UnconnectedReservationInformationForm extends Component {
 
   renderUniversalFields() {
     const { resource } = this.props;
-    const elements = resource.universalField.reduce((allElements, curr) => {
-      // what sort of element, select? radio?
-      const fieldType = curr.fieldType ? curr.fieldType.toLowerCase() : '';
-      const currentOptions = curr.options;
-      // normalize options
-      const options = currentOptions.reduce((allOpts, option) => {
-        allOpts.push({ id: option.id, name: option.text, value: option.id });
-        return allOpts;
-      }, []);
-      // the key name that redux-form uses, currently only works for 1 universal field per resource.
-      const nameValue = resource.universalField.length > 1 ? `universalData-${curr.id}` : 'universalData';
-      const universalProps = {
-        id: curr.id,
-        description: curr.description,
-        label: curr.label,
-        options: currentOptions,
-      };
-      allElements.push(this.renderField(
-        nameValue,
-        `componenttype-${curr.id}`,
-        fieldType,
-        curr.label,
-        {
-          options
-        },
+    return normalizeUniversalFieldOptions(resource.universalField, resource)
+      .map(element => this.renderField(
+        element.name,
+        element.fieldName,
+        element.type,
+        element.label,
+        element.controlProps,
         null,
         null,
         false,
-        universalProps,
+        element.universalProps
       ));
-      return allElements;
-    }, []);
-    return elements;
   }
 
   render() {

--- a/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js
+++ b/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { createSelector } from 'reselect';
 
 import UnpublishedLabel from 'shared/label/Unpublished';
+import Label from 'shared/label';
 import { injectT } from 'i18n';
 import { resourcesSelector } from 'state/selectors/dataSelectors';
 
@@ -17,11 +18,19 @@ ResourceInfo.propTypes = {
   name: PropTypes.string.isRequired,
   peopleCapacity: PropTypes.number,
   public: PropTypes.bool.isRequired,
+  hasStaffRights: PropTypes.bool,
+  t: PropTypes.func.isRequired,
 };
 export function ResourceInfo(props) {
   return (
     <div
-      className={classNames('resource-info', { 'resource-info-selected': props.isSelected })}
+      className={classNames(
+        'resource-info',
+        {
+          'resource-info-selected': props.isSelected,
+          'is-external': !props.hasStaffRights
+        })
+    }
       title={props.name}
     >
       <div className="name">
@@ -33,6 +42,11 @@ export function ResourceInfo(props) {
         {props.peopleCapacity}
         {!props.public && (
           <UnpublishedLabel />
+        )}
+        {!props.hasStaffRights && (
+          <Label bsStyle="default" className="unpublished-label">
+            {props.t('AdminResourcesPage.external.label')}
+          </Label>
         )}
       </div>
     </div>
@@ -50,11 +64,15 @@ export function selector() {
   );
   return createSelector(
     resourceSelector,
-    resource => ({
-      name: resource.name,
-      peopleCapacity: resource.peopleCapacity,
-      public: resource.public,
-    })
+    resource => {
+      const { isAdmin, isManager, isViewer } = resource.userPermissions;
+      return {
+        name: resource.name,
+        peopleCapacity: resource.peopleCapacity,
+        public: resource.public,
+        hasStaffRights: isAdmin || isManager || isViewer
+      };
+    }
   );
 }
 

--- a/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.spec.js
+++ b/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.spec.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { shallowWithIntl } from 'utils/testUtils';
 import { UnconnectedResourceInfo as ResourceInfo, selector } from './ResourceInfoContainer';
 import UnpublishedLabel from 'shared/label/Unpublished';
+import Label from 'shared/label';
 
 function getState() {
   return {
@@ -16,6 +17,11 @@ function getState() {
           isFavorite: false,
           peopleCapacity: 9,
           public: true,
+          userPermissions: {
+            isAdmin: false,
+            isManager: true,
+            isViewer: false
+          }
         },
       },
     },
@@ -32,6 +38,7 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
       name: 'Resource name',
       peopleCapacity: 19,
       public: true,
+      hasStaffRights: true,
     };
     return shallowWithIntl(<ResourceInfo {...defaults} {...props} />);
   }
@@ -70,6 +77,16 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
     expect(label).toHaveLength(0);
   });
 
+  test('renders external label if the user does not has staff rights for the resource', () => {
+    const label = getWrapper({ hasStaffRights: false }).find(Label);
+    expect(label).toHaveLength(1);
+  });
+
+  test('does not render external label if the user does has staff rights for the resource', () => {
+    const label = getWrapper({ hasStaffRights: true }).find(Label);
+    expect(label).toHaveLength(0);
+  });
+
   describe('selector', () => {
     function getSelected(props) {
       const defaults = { id: '123456' };
@@ -82,6 +99,7 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
         name: 'Resource Name',
         peopleCapacity: 9,
         public: true,
+        hasStaffRights: true,
       });
     });
   });

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.spec.js
@@ -11,6 +11,7 @@ function getState() {
       resources: {
         'resource-1': {
           id: 'resource-1',
+          userPermissions: {},
           reservations: [
             {
               id: 111,
@@ -46,7 +47,7 @@ function getState() {
             },
           ],
         },
-        'resource-2': { id: 'resource-2' },
+        'resource-2': { id: 'resource-2', userPermissions: {}, },
       },
     },
   };

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.js
@@ -60,6 +60,11 @@ class ConfirmReservationModal extends Component {
       formFields.push('reserverEmailAddress');
       formFields.push('reserverPhoneNumber');
     }
+    if (resource.universalField && resource.universalField.length) {
+      // resource.universalField.forEach(val => formFields.push(`universalData-${val.id}`));
+      // TODO: atm only works with one field, change to above to support multiple ones.
+      formFields.push('universalData');
+    }
 
     /* Field hidden until it is needed again
     if (resource.needManualConfirmation && isStaff) {

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
@@ -7,7 +7,7 @@ import simple from 'simple-mock';
 import CompactReservationList from 'shared/compact-reservation-list';
 import RecurringReservationControls from 'shared/recurring-reservation-controls';
 import Reservation from 'utils/fixtures/Reservation';
-import Resource from 'utils/fixtures/Resource';
+import Resource, { UniversalField } from 'utils/fixtures/Resource';
 import { shallowWithIntl } from 'utils/testUtils';
 import ConfirmReservationModal from './ConfirmReservationModal';
 import ReservationForm from './ReservationForm';
@@ -219,6 +219,18 @@ describe('shared/reservation-confirmation/ConfirmReservationModal', () => {
       test('is not included if resource does not contain any terms', () => {
         const resource = Resource.build({ genericTerms: null });
         expect(getFormFields({ resource })).toEqual(expect.not.arrayContaining(['termsAndConditions']));
+      });
+    });
+
+    describe('universalData', () => {
+      test('is included if resource contains universalField', () => {
+        const resource = Resource.build({ universalField: [UniversalField.build()] });
+        expect(getFormFields({ resource })).toEqual(expect.arrayContaining(['universalData']));
+      });
+
+      test('is not included if resource does not contain universalField', () => {
+        const resource = Resource.build();
+        expect(getFormFields({ resource })).toEqual(expect.not.arrayContaining(['universalData']));
       });
     });
   });

--- a/app/shared/reservation-confirmation/ReservationForm.spec.js
+++ b/app/shared/reservation-confirmation/ReservationForm.spec.js
@@ -9,7 +9,7 @@ import constants from 'constants/AppConstants';
 import WrappedText from 'shared/wrapped-text';
 import { shallowWithIntl } from 'utils/testUtils';
 import { UnconnectedReservationForm as ReservationForm, validate } from './ReservationForm';
-import Resource from 'utils/fixtures/Resource';
+import Resource, { UniversalField } from 'utils/fixtures/Resource';
 
 describe('shared/reservation-confirmation/ReservationForm', () => {
   describe('validation', () => {
@@ -378,6 +378,31 @@ describe('shared/reservation-confirmation/ReservationForm', () => {
 
           expect(inputWrapper.length).toBe(0);
         });
+      });
+    });
+    describe('universal field', () => {
+      test('is rendered when resource has a universal field', () => {
+        const mockUniversalField = UniversalField.build();
+        const resource = Resource.build({ universalField: [mockUniversalField] });
+        const fields = ['universalData'];
+        const element = getWrapper({ fields, resource }).find(Field);
+        expect(element).toHaveLength(1);
+        const elementProps = element.props();
+        expect(elementProps.type).toBe('select');
+        expect(elementProps.label).toBe(mockUniversalField.label);
+        const expectedControlProps = {
+          options: mockUniversalField.options.map(opt => ({
+            id: opt.id,
+            value: opt.id,
+            name: opt.text,
+          }))
+        };
+        expect(elementProps.controlProps).toEqual(expectedControlProps);
+        const expectedFieldData = {
+          data: null,
+          description: mockUniversalField.description,
+        };
+        expect(elementProps.universalFieldData).toEqual(expectedFieldData);
       });
     });
 

--- a/app/shared/resource-type-filter/ResourceTypeFilterContainer.js
+++ b/app/shared/resource-type-filter/ResourceTypeFilterContainer.js
@@ -11,6 +11,9 @@ class ResourceTypeFilterContainer extends Component {
     onSelectResourceType: PropTypes.func.isRequired,
     onUnselectResourceType: PropTypes.func.isRequired,
     resourceTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    toggleShowExternalResources: PropTypes.func,
+    externalResources: PropTypes.array,
+    showExternalResources: PropTypes.bool,
     t: PropTypes.func.isRequired,
   };
 
@@ -28,10 +31,25 @@ class ResourceTypeFilterContainer extends Component {
   }
 
   render() {
-    const { t, selectedResourceTypes, resourceTypes } = this.props;
+    const {
+      t,
+      selectedResourceTypes,
+      resourceTypes,
+      externalResources,
+      showExternalResources,
+      toggleShowExternalResources
+    } = this.props;
     return (
       <div className="resource-type-filter-container">
         <h6>{t('ResourceTypeFilter.title')}</h6>
+        { externalResources.length > 0 && (
+          <ResourceTypeFilterButton
+            active={showExternalResources}
+            key={`resource-external-${externalResources[0]}`}
+            onClick={toggleShowExternalResources}
+            resourceType={t('AdminResourcesPage.external.toggle')}
+          />
+        )}
         { resourceTypes.map(resourceType => (
           <ResourceTypeFilterButton
             active={includes(selectedResourceTypes, resourceType)}

--- a/app/shared/resource-type-filter/ResourceTypeFilterContainer.spec.js
+++ b/app/shared/resource-type-filter/ResourceTypeFilterContainer.spec.js
@@ -12,6 +12,9 @@ describe('shared/resource-type-filter/ResourceTypeFilterContainer', () => {
     onUnselectResourceType: simple.mock(),
     resourceTypes: ['a', 'b', 'c'],
     selectedResourceTypes: ['a'],
+    externalResources: [],
+    showExternalResources: false,
+    toggleShowExternalResources: jest.fn(),
   };
 
   function getWrapper(props) {
@@ -55,6 +58,27 @@ describe('shared/resource-type-filter/ResourceTypeFilterContainer', () => {
       test('passes correct active prop', () => {
         expect(resourceTypeFilter.prop('active')).toBe(false);
       });
+    });
+  });
+  describe('ResourceTypeFilter when externalResources exist', () => {
+    const mockProps = {
+      toggleShowExternalResources: jest.fn(),
+      showExternalResources: true,
+      externalResources: ['resource1']
+    };
+    const viewerWrapper = getWrapper(mockProps);
+    test('first Button is the toggle for externalResources and has correct props', () => {
+      const element = viewerWrapper.find(ResourceTypeFilterButton).at(0);
+      expect(element.prop('onClick')).toBe(mockProps.toggleShowExternalResources);
+      expect(element.prop('resourceType')).toBe('AdminResourcesPage.external.toggle');
+      expect(element.prop('active')).toBe(mockProps.showExternalResources);
+    });
+    test('the remaining buttons are rendered correctly', () => {
+      const allButtons = viewerWrapper.find(ResourceTypeFilterButton);
+      expect(allButtons).toHaveLength(4);
+      expect(allButtons.at(1).prop('resourceType')).toBe('a');
+      expect(allButtons.at(2).prop('resourceType')).toBe('b');
+      expect(allButtons.at(3).prop('resourceType')).toBe('c');
     });
   });
 

--- a/app/utils/__tests__/reservationUtils.spec.js
+++ b/app/utils/__tests__/reservationUtils.spec.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import constants from 'constants/AppConstants';
 import Reservation from 'utils/fixtures/Reservation';
+import Resource, { UniversalField } from 'utils/fixtures/Resource';
 import {
   combine,
   isStaffEvent,
@@ -29,6 +30,7 @@ import {
   getInitialProducts,
   getReservationCustomerGroupName,
   isManuallyConfirmedWithOrderAllowed,
+  normalizeUniversalFieldOptions,
 } from 'utils/reservationUtils';
 import { buildAPIUrl, getHeadersCreator } from '../apiUtils';
 import Product from '../fixtures/Product';
@@ -765,6 +767,33 @@ describe('Utils: reservationUtils', () => {
       const state = states.READY_FOR_PAYMENT;
       const reservation = Reservation.build({ needManualConfirmation, order, state });
       expect(isManuallyConfirmedWithOrderAllowed(reservation)).toBe(false);
+    });
+  });
+  describe('normalizeUniversalFieldOptions', () => {
+    test('returns array with objects where values have been normalized', () => {
+      const universalField = UniversalField.build();
+      const resource = Resource.build({ universalField: [universalField] });
+      const returnValues = normalizeUniversalFieldOptions(resource.universalField, resource);
+      const expectedValues = {
+        fieldName: `componenttype-${universalField.id}`,
+        label: universalField.label,
+        name: 'universalData',
+        type: 'select',
+        controlProps: {
+          options: universalField.options.map(opt => ({
+            id: opt.id,
+            value: opt.id,
+            name: opt.text,
+          })),
+        },
+        universalProps: {
+          id: universalField.id,
+          description: universalField.description,
+          label: universalField.label,
+          options: universalField.options,
+        },
+      };
+      expect(returnValues).toEqual([expectedValues]);
     });
   });
 });

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -375,6 +375,43 @@ function isManuallyConfirmedWithOrderAllowed(reservation) {
   return false;
 }
 
+/**
+ * Returns array with obj values for each option.
+ * @param {Object[]} universalField
+ * @param {Object} resource
+ */
+function normalizeUniversalFieldOptions(universalField, resource) {
+  return universalField.reduce((acc, curr) => {
+    // what sort of element, select? radio?
+    const fieldType = curr.fieldType ? curr.fieldType.toLowerCase() : '';
+    const currentOptions = curr.options;
+    // normalize options
+    const options = currentOptions.reduce((allOpts, option) => {
+      allOpts.push({ id: option.id, name: option.text, value: option.id });
+      return allOpts;
+    }, []);
+    // the key name that redux-form uses, currently only works for 1 universal field per resource.
+    const nameValue = resource.universalField.length > 1 ? `universalData-${curr.id}` : 'universalData';
+    const universalProps = {
+      id: curr.id,
+      description: curr.description,
+      label: curr.label,
+      options: currentOptions,
+    };
+    acc.push(
+      {
+        name: nameValue,
+        fieldName: `componenttype-${curr.id}`,
+        type: fieldType,
+        label: curr.label,
+        controlProps: { options },
+        universalProps
+      }
+    );
+    return acc;
+  }, []);
+}
+
 export {
   combine,
   isStaffEvent,
@@ -399,4 +436,5 @@ export {
   getPaymentReturnUrl,
   getReservationCustomerGroupName,
   isManuallyConfirmedWithOrderAllowed,
+  normalizeUniversalFieldOptions,
 };


### PR DESCRIPTION


# Staff can make reservations for customers to external resources


#### Staff users can create reservations for customers to external resources via the 'Omat tilat' page. A resource must have `reservable_by_all_staff` set to `True` in order for the resource to be available to all users with staff rights. Once the resource is available, it must be set as a favorite so that it shows up in the 'Omat tilat' page. 
The staff user can create reservations for customers to the external resources but all reservable_after/opening hours restrictions apply (eg reservation must be made 5 days before current date etc).

[Trello card for this feature.](https://trello.com/c/gTnO4cXg/341-digineuvojan-ajan-varaaminen)
-----------------------------------------------------------------------------------------------
Changes:

- pages/admin-resources/AdminResourcesPage.js:
External resources are added to resources depending on the new state boolean value `showExternalResources`.
Added function `toggleShowExternalResources` which toggles the boolean state.
Passing new props to ResourceTypeFilter.

- pages/admin-resources/AdminResourcesPage.spec.js:
Updated tests

- pages/admin-resources/adminResourcesPageSelector.js:
Added new `externalResourcesSelector` which returns resources where `resource.userPermissions.CanMakeReservationsForCustomer` is true and it isn't already included adminResources.
Added new `filteredExternalResourcesSelector` which returns an array of objects based on the resources that `externalResourcesSelector` returns.
Added new `externalResources` selector containing the output of `filteredExternalResourcesSelector`.

- pages/admin-resources/adminResourcesPageSelector.spec.js:
Updated and refactored old tests
 
- pages/reservation/reservation-information/ReservationInformationForm.js:
Moved the reducer from the `renderUniversalFields` function to `reservationUtils.js` because the same reducer is now used in multiple places.
 
- shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js:
Added additional label which is rendered if the resource is external. Resources are external is the user doesn't have admin, manager or viewer permissions.

- shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.spec.js:
Added tests.

- availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.spec.js:
Updated tests.

- shared/availability-view/TimelineGroups/TimelineGroup/utils.js:
Modified `addSelectionData` so that items are not selectable if the resource is external and the timeslot is before the `reservableAfter` date/value of the resource.

- shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js:
Updated and added new tests for the `addSelectionData` changes.

- shared/reservation-confirmation/ConfirmReservationModal.js:
`universalData` is added to `formFields` if the resource has a universal field.

- shared/reservation-confirmation/ConfirmReservationModal.spec.js:
Added tests to check that `getFormFields` contains `universalData` if the resource has a universal field.

- shared/reservation-confirmation/ReservationForm.js:
Added new field that is rendered if the resource has a universal field.

- shared/reservation-confirmation/ReservationForm.spec.js:
Added tests to check that form includes Field for the universal field if the resource has one.

- shared/resource-type-filter/ResourceTypeFilterContainer.js:
Added new props `toggleShowExternalResources`, `externalResources` and `showExternalResources`. These props are passed from `AdminResourcesPage`. A new button is rendered if `externalResources` exist, button active state is determined by `showExternalResources` and onClick calls `toggleShowExternalResources`. This button is used to toggle the visibility of the external resources (if they are added to resources in `AdminResourcesPage`).

- shared/resource-type-filter/ResourceTypeFilterContainer.spec.js:
Added tests.

- utils/reservationUtils.js:
The new `normalizeUniversalFieldOptions` function was previously in `ReservationInformationForm.js` but it was moved here because it is now needed in multiple places.

- utils/tests__/reservationUtils.spec.js:
Added test for `normalizeUniversalFieldOptions`.

- i18n/[en, fi , sv].json:
Added new texts that are used in the button that is rendered by `ResourceTypeFilterContainer.js`.

