### PR TITLE
Updated reservation phone field error text

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -298,7 +298,7 @@
   "ReservationForm.numberOfParticipants.overError": "Number of participants is over max capacity {peopleCapacity}",
   "ReservationForm.numberOfParticipants.underError": "There needs to be at least one participant",
   "ReservationForm.maxLengthError": "The maximum length of the field is {maxLength} characters",
-  "ReservationForm.phoneNumberError": "Enter a valid phone number which can start with character '+' and otherwise contains only numbers",
+  "ReservationForm.phoneNumberError": "Enter a phone number that can start with character '+', doesn't contain any spaces and only contains numbers e.g. 0401234567",
   "ReservationForm.requiredError": "Mandatory information",
   "ReservationForm.staffEventHelp": "The Department’s own events are approved automatically and the only mandatory information is the name of the person making the reservation and a description of the event.",
   "ReservationForm.staffEventLabel": "The Department’s own events",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -298,7 +298,7 @@
   "ReservationForm.numberOfParticipants.overError": "Osallistujamäärä on yli maksimikapasiteetin {peopleCapacity}",
   "ReservationForm.numberOfParticipants.underError": "Osallistujamäärän on oltava vähintään yksi",
   "ReservationForm.maxLengthError": "Kentän maksimipituus on {maxLength} merkkiä",
-  "ReservationForm.phoneNumberError": "Syötä kunnollinen puhelinnumero, joka voi alkaa +-merkillä ja sisältää vain numeroita",
+  "ReservationForm.phoneNumberError": "Syötä puhelinnumero, joka voi alkaa +-merkillä, ei sisällä välilyöntejä ja sisältää vain numeroita esim. 0401234567",
   "ReservationForm.requiredError": "Pakollinen tieto",
   "ReservationForm.staffEventHelp": "Viraston oma tapahtuma hyväksytään automaattisesti ja ainoat pakolliset tiedot ovat varaajan nimi ja tilaisuuden kuvaus.",
   "ReservationForm.staffEventLabel": "Viraston oma tapahtuma",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -300,7 +300,7 @@
   "ReservationForm.numberOfParticipants.overError": "Antalet deltagare är över det tillåtna {peopleCapacity}",
   "ReservationForm.numberOfParticipants.underError": "Det måste vara minst en deltagare",
   "ReservationForm.maxLengthError": "Den maximala längden på fältet är {maxLength} tecken",
-  "ReservationForm.phoneNumberError": "Ange ett giltigt telefonnummer som kan börja med ett '+' tecken och som endast innehåller nummer",
+  "ReservationForm.phoneNumberError": "Ange ett telefonnummer som kan börja med ett '+', inte innehåller några mellanslag och innehåller endast nummer t.ex. 0401234567",
   "ReservationForm.requiredError": "Obligatorisk information",
   "ReservationForm.staffEventHelp": "Verkets egna evenemang godkänns automatiskt och de enda obligatoriska uppgifterna är namnet på personen som bokar utrymmet och beskrivningen av evenemanget.",
   "ReservationForm.staffEventLabel": "Verkets eget evenemang",


### PR DESCRIPTION
# Reservation phone field error text

## The error text now tells that empty spaces are not allowed and gives an example phone number

### [Related Trello card](https://trello.com/c/HJb8SSHm)