### PR TITLE
Added form level error list for reservation form

### DIFF
--- a/app/constants/ReservationConstants.js
+++ b/app/constants/ReservationConstants.js
@@ -1,0 +1,83 @@
+export const FIELDS = {
+  // common fields
+  RESERVER_NAME: {
+    id: 'reserverName', label: 'common.reserverNameLabel', forBilling: false, order: 0
+  },
+  COMPANY: {
+    id: 'company', label: 'common.companyLabel', forBilling: false, order: 1
+  },
+  RESERVER_ID: {
+    id: 'reserverId', label: 'common.reserverIdLabel', forBilling: false, order: 2
+  },
+  RESERVER_PHONE_NUMBER: {
+    id: 'reserverPhoneNumber', label: 'common.reserverPhoneNumberLabel', forBilling: false, order: 3
+  },
+  RESERVER_EMAIL_ADDRESS: {
+    id: 'reserverEmailAddress', label: 'common.reserverEmailAddressLabel', forBilling: false, order: 4
+  },
+  RESERVER_ADDRESS_STREET: {
+    id: 'reserverAddressStreet', label: 'common.addressStreetLabel', forBilling: false, order: 5
+  },
+  RESERVER_ADDRESS_ZIP: {
+    id: 'reserverAddressZip', label: 'common.addressZipLabel', forBilling: false, order: 6
+  },
+  RESERVER_ADDRESS_CITY: {
+    id: 'reserverAddressCity', label: 'common.addressCityLabel', forBilling: false, order: 7
+  },
+  HOME_MUNICIPALITY: {
+    id: 'homeMunicipality', label: 'common.homeMunicipality', forBilling: false, order: 8
+  },
+  EVENT_SUBJECT: {
+    id: 'eventSubject', label: 'common.eventSubjectLabel', forBilling: false, order: 16
+  },
+  EVENT_DESCRIPTION: {
+    id: 'eventDescription', label: 'common.eventDescriptionLabel', forBilling: false, order: 17
+  },
+  NUMBER_OF_PARTICIPANTS: {
+    id: 'numberOfParticipants', label: 'common.numberOfParticipantsLabel', forBilling: false, order: 18
+  },
+  REQUIRE_ASSISTANCE: {
+    id: 'requireAssistance', label: 'common.requireAssistanceLabel', forBilling: false, order: 19
+  },
+  REQUIRE_WORKSTATION: {
+    id: 'requireWorkstation', label: 'common.requireWorkstationLabel', forBilling: false, order: 20
+  },
+  COMMENTS: {
+    id: 'comments', label: 'common.commentsLabel', forBilling: false, order: 21
+  },
+  RESERVATION_EXTRA_QUESTIONS: {
+    id: 'reservationExtraQuestions', label: 'common.additionalInfo.label', forBilling: false, order: 22
+  },
+  // terms fields are special, they have common starting label and unique end link label
+  TERMS_AND_CONDITIONS: {
+    id: 'termsAndConditions', label: 'ReservationInformationForm.termsAndConditionsLink', forBilling: false, order: 23
+  },
+  PAYMENT_TERMS_AND_CONDITIONS: {
+    id: 'paymentTermsAndConditions', label: 'ReservationInformationForm.paymentTermsAndConditionsLink', forBilling: false, order: 24
+  },
+  // billing fields
+  BILLING_FIRST_NAME: {
+    id: 'billingFirstName', label: 'common.billingFirstNameLabel', forBilling: true, order: 9
+  },
+  BILLING_LAST_NAME: {
+    id: 'billingLastName', label: 'common.billingLastNameLabel', forBilling: true, order: 10
+  },
+  BILLING_EMAIL_ADDRESS: {
+    id: 'billingEmailAddress', label: 'common.billingEmailAddressLabel', forBilling: true, order: 12
+  },
+  BILLING_PHONE_NUMBER: {
+    id: 'billingPhoneNumber', label: 'common.billingPhoneNumberLabel', forBilling: true, order: 11
+  },
+  BILLING_ADDRESS_STREET: {
+    id: 'billingAddressStreet', label: 'common.addressStreetLabel', forBilling: true, order: 13
+  },
+  BILLING_ADDRESS_ZIP: {
+    id: 'billingAddressZip', label: 'common.addressZipLabel', forBilling: true, order: 14
+  },
+  BILLING_ADDRESS_CITY: {
+    id: 'billingAddressCity', label: 'common.addressCityLabel', forBilling: true, order: 15
+  },
+};
+
+
+

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -309,6 +309,7 @@
   "ReservationForm.universalField.pictureAlt": "Picture that relates to the '{label}' field.",
   "ReservationForm.universalField.iframe.skipToAfter": "Skip over the embedded iframe.",
   "ReservationForm.universalField.iframe.skipToBefore": "Skip to before the embedded iframe.",
+  "ReservationForm.validation.payer.label": "Payer",
   "ReservationInfo.loginMessage": "You must <a>log in<a> to reserve these premises.",
   "ReservationInfo.loginMessageStrongAuth": "You must <a>log in<a> with Suomi.fi to reserve these premises.",
   "ReservationInfo.maxNumberOfReservations": "Maximum number of reservations per user:",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -309,6 +309,7 @@
   "ReservationForm.universalField.pictureAlt": "Kuva joka liittyy '{label}' kenttään.",
   "ReservationForm.universalField.iframe.skipToAfter": "Siirry iframe-upotuksen yli.",
   "ReservationForm.universalField.iframe.skipToBefore": "Siirry takaisin ennen iframe-upotusta.",
+  "ReservationForm.validation.payer.label": "Maksajan",
   "ReservationInfo.loginMessage": "Sinun täytyy <a>kirjautua sisään<a>, jotta voit tehdä varauksen tähän tilaan.",
   "ReservationInfo.loginMessageStrongAuth": "Sinun täytyy <a>kirjautua sisään<a> Suomi.fi:llä, jotta voit tehdä varauksen tähän tilaan.",
   "ReservationInfo.maxNumberOfReservations": "Maksimimäärä varauksia per käyttäjä:",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -311,6 +311,7 @@
   "ReservationForm.universalField.pictureAlt": "Bild som är relaterat till '{label}' fältet.",
   "ReservationForm.universalField.iframe.skipToAfter": "Hoppa över iframe-inbäddningen.",
   "ReservationForm.universalField.iframe.skipToBefore": "Hoppa tillbaka före iframe-inbäddningen.",
+  "ReservationForm.validation.payer.label": "Betalarens",
   "ReservationInfo.loginMessage": "För att kunna boka detta utrymme måste du <a>logga in<a>.",
   "ReservationInfo.loginMessageStrongAuth": "För att kunna boka detta utrymme måste du <a>logga in<a> via Suomi.fi.",
   "ReservationInfo.maxNumberOfReservations": "Maximalt antal bokningar per användare:",

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -2,10 +2,13 @@
 import includes from 'lodash/includes';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Button from 'react-bootstrap/lib/Button';
 import Form from 'react-bootstrap/lib/Form';
 import Well from 'react-bootstrap/lib/Well';
-import { Field, reduxForm } from 'redux-form';
+import {
+  Field, reduxForm, getFormSyncErrors, getFormValues
+} from 'redux-form';
 import isEmail from 'validator/lib/isEmail';
 
 import FormTypes from 'constants/FormTypes';
@@ -17,6 +20,8 @@ import { injectT } from 'i18n';
 import ReservationTermsModal from 'shared/modals/reservation-terms';
 import WrappedText from 'shared/wrapped-text/WrappedText';
 import ReservationSubmitButton from './ReservationSubmitButton';
+import ReservationValidationErrors from './ReservationValidationErrors';
+import { FIELDS } from '../../../constants/ReservationConstants';
 
 const validators = {
   reserverEmailAddress: (t, { reserverEmailAddress }) => {
@@ -128,6 +133,36 @@ export function validate(values, {
 }
 
 class UnconnectedReservationInformationForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showFormErrorList: false,
+      formErrors: [],
+    };
+
+    this.handleFormSubmit = this.handleFormSubmit.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { showFormErrorList } = this.state;
+    const { formValues } = this.props;
+    if (showFormErrorList) {
+      if (formValues !== prevProps.formValues) {
+        this.setState({ showFormErrorList: false, formErrors: [] });
+      }
+    }
+  }
+
+  handleFormSubmit() {
+    const { formSyncErrors, handleSubmit, onConfirm } = this.props;
+    if (formSyncErrors && Object.keys(formSyncErrors).length > 0) {
+      this.setState({ showFormErrorList: true, formErrors: Object.keys(formSyncErrors) });
+    }
+
+    handleSubmit(onConfirm);
+  }
+
+
   // name is required by the Field component and is used to point to field's value.
   // fieldName is the actual html attribute name which is used for autocomplete etc.
   // eslint-disable-next-line react/sort-comp
@@ -263,39 +298,39 @@ class UnconnectedReservationInformationForm extends Component {
             </Well>
           )}
           {this.renderField(
-            'reserverName',
+            FIELDS.RESERVER_NAME.id,
             'name',
             'text',
-            t('common.reserverNameLabel'),
+            t(FIELDS.RESERVER_NAME.label),
             { autoComplete: 'name' },
           )}
           {this.renderField(
-            'company',
+            FIELDS.COMPANY.id,
             'company',
             'text',
-            t('common.companyLabel'),
+            t(FIELDS.COMPANY.label),
             {}
           )}
           {this.renderField(
-            'reserverId',
+            FIELDS.RESERVER_ID.id,
             'reserverId',
             'text',
-            t('common.reserverIdLabel'),
+            t(FIELDS.RESERVER_ID.label),
             { placeholder: t('common.reserverIdLabel') }
           )}
           {this.renderField(
-            'reserverPhoneNumber',
+            FIELDS.RESERVER_PHONE_NUMBER.id,
             'phone',
             'text',
-            t('common.reserverPhoneNumberLabel'),
+            t(FIELDS.RESERVER_PHONE_NUMBER.label),
             { autoComplete: 'tel' },
             t('common.contactPurposeHelp'),
           )}
           {this.renderField(
-            'reserverEmailAddress',
+            FIELDS.RESERVER_EMAIL_ADDRESS.id,
             'email',
             'email',
-            t('common.reserverEmailAddressLabel'),
+            t(FIELDS.RESERVER_EMAIL_ADDRESS.label),
             { autoComplete: 'email' },
             t('common.contactPurposeHelp'),
           )}
@@ -304,35 +339,35 @@ class UnconnectedReservationInformationForm extends Component {
           }
           {includes(this.props.fields, 'reserverAddressStreet')
             && this.renderField(
-              'reserverAddressStreet',
+              FIELDS.RESERVER_ADDRESS_STREET.id,
               'address',
               'text',
-              t('common.addressStreetLabel'),
+              t(FIELDS.RESERVER_ADDRESS_STREET.label),
               { autoComplete: 'street-address' },
             )}
           {includes(this.props.fields, 'reserverAddressZip')
             && this.renderField(
-              'reserverAddressZip',
+              FIELDS.RESERVER_ADDRESS_ZIP.id,
               'zip',
               'text',
-              t('common.addressZipLabel'),
+              t(FIELDS.RESERVER_ADDRESS_ZIP.label),
               { autoComplete: 'postal-code' },
             )}
           {includes(this.props.fields, 'reserverAddressCity')
             && this.renderField(
-              'reserverAddressCity',
+              FIELDS.RESERVER_ADDRESS_CITY.id,
               'city',
               'text',
-              t('common.addressCityLabel'),
+              t(FIELDS.RESERVER_ADDRESS_CITY.label),
               { autoComplete: 'address-level2' },
             )
           }
           {includes(this.props.fields, 'homeMunicipality')
             && this.renderField(
-              'homeMunicipality',
+              FIELDS.HOME_MUNICIPALITY.id,
               'municipality',
               'select',
-              t('common.homeMunicipality'),
+              t(FIELDS.HOME_MUNICIPALITY.label),
               { options: resource.includedReservationHomeMunicipalityFields },
             )
           }
@@ -347,64 +382,64 @@ class UnconnectedReservationInformationForm extends Component {
           }
           {includes(this.props.fields, 'billingFirstName')
             && this.renderField(
-              'billingFirstName',
+              FIELDS.BILLING_FIRST_NAME.id,
               'cc-given-name',
               'text',
-              t('common.billingFirstNameLabel'),
+              t(FIELDS.BILLING_FIRST_NAME.label),
               { autoComplete: 'cc-given-name' },
             )
           }
           {includes(this.props.fields, 'billingLastName')
             && this.renderField(
-              'billingLastName',
+              FIELDS.BILLING_LAST_NAME.id,
               'cc-family-name',
               'text',
-              t('common.billingLastNameLabel'),
+              t(FIELDS.BILLING_LAST_NAME.label),
               { autoComplete: 'cc-family-name' },
             )
           }
           {includes(this.props.fields, 'billingPhoneNumber')
             && this.renderField(
-              'billingPhoneNumber',
+              FIELDS.BILLING_PHONE_NUMBER.id,
               'phone',
               'tel',
-              t('common.billingPhoneNumberLabel'),
+              t(FIELDS.BILLING_PHONE_NUMBER.label),
               { autoComplete: 'tel' },
             )
           }
           {includes(this.props.fields, 'billingEmailAddress')
             && this.renderField(
-              'billingEmailAddress',
+              FIELDS.BILLING_EMAIL_ADDRESS.id,
               'email',
               'email',
-              t('common.billingEmailAddressLabel'),
+              t(FIELDS.BILLING_EMAIL_ADDRESS.label),
               { autoComplete: 'email' },
             )
           }
           {includes(this.props.fields, 'billingAddressStreet')
             && this.renderField(
-              'billingAddressStreet',
+              FIELDS.BILLING_ADDRESS_STREET.id,
               'address',
               'text',
-              t('common.addressStreetLabel'),
+              t(FIELDS.BILLING_ADDRESS_STREET.label),
               { autoComplete: 'street-address' },
             )
           }
           {includes(this.props.fields, 'billingAddressZip')
             && this.renderField(
-              'billingAddressZip',
+              FIELDS.BILLING_ADDRESS_ZIP.id,
               'zip',
               'text',
-              t('common.addressZipLabel'),
+              t(FIELDS.BILLING_ADDRESS_ZIP.label),
               { autoComplete: 'postal-code' },
             )
           }
           {includes(this.props.fields, 'billingAddressCity')
             && this.renderField(
-              'billingAddressCity',
+              FIELDS.BILLING_ADDRESS_CITY.id,
               'city',
               'text',
-              t('common.addressCityLabel'),
+              t(FIELDS.BILLING_ADDRESS_CITY.label),
               { autoComplete: 'address-level2' },
             )
           }
@@ -416,52 +451,52 @@ class UnconnectedReservationInformationForm extends Component {
           && <h3 className="ReservationInformationForm">{t('ReservationInformationForm.eventInformationTitle')}</h3>
         }
           {this.renderField(
-            'eventSubject',
+            FIELDS.EVENT_SUBJECT.id,
             'eventSubject',
             'text',
-            t('common.eventSubjectLabel'),
+            t(FIELDS.EVENT_SUBJECT.label),
             {},
             null,
           )}
           {this.renderField(
-            'eventDescription',
+            FIELDS.EVENT_DESCRIPTION.id,
             'eventDescription',
             'textarea',
-            t('common.eventDescriptionLabel'),
+            t(FIELDS.EVENT_DESCRIPTION.label),
             { rows: 5 }
           )}
           {this.renderField(
-            'numberOfParticipants',
+            FIELDS.NUMBER_OF_PARTICIPANTS.id,
             'numberOfParticipants',
             'number',
-            t('common.numberOfParticipantsLabel'),
+            t(FIELDS.NUMBER_OF_PARTICIPANTS.label),
             { min: '1', max: resource.peopleCapacity }
           )}
           {this.renderField(
-            'requireAssistance',
+            FIELDS.REQUIRE_ASSISTANCE.id,
             'requireAssistance',
             'checkbox',
-            t('common.requireAssistanceLabel'),
+            t(FIELDS.REQUIRE_ASSISTANCE.label),
             {},
             null,
             null,
             true
           )}
           {this.renderField(
-            'requireWorkstation',
+            FIELDS.REQUIRE_WORKSTATION.id,
             'requireWorkstation',
             'checkbox',
-            t('common.requireWorkstationLabel'),
+            t(FIELDS.REQUIRE_WORKSTATION.label),
             {},
             null,
             null,
             true
           )}
           {this.renderField(
-            'comments',
+            FIELDS.COMMENTS.id,
             'comments',
             'textarea',
-            t('common.commentsLabel'),
+            t(FIELDS.COMMENTS.label),
             {
               placeholder: t('common.commentsPlaceholder'),
               rows: 5,
@@ -481,10 +516,10 @@ class UnconnectedReservationInformationForm extends Component {
             )
           }
           {this.renderField(
-            'reservationExtraQuestions',
+            FIELDS.RESERVATION_EXTRA_QUESTIONS.id,
             'reservationExtraQuestions',
             'textarea',
-            t('common.additionalInfo.label'),
+            t(FIELDS.RESERVATION_EXTRA_QUESTIONS.label),
             {
               rows: 5,
             }
@@ -513,11 +548,15 @@ class UnconnectedReservationInformationForm extends Component {
               )
             }
             <ReservationSubmitButton
-              handleSubmit={handleSubmit}
+              handleFormSubmit={this.handleFormSubmit}
               hasPayment={hasPayment}
               isMakingReservations={isMakingReservations}
               needManualConfirmation={resource.needManualConfirmation}
-              onConfirm={onConfirm}
+            />
+            <ReservationValidationErrors
+              formErrors={this.state.formErrors}
+              showFormErrorList={this.state.showFormErrorList}
+              universalFields={resource.universalField}
             />
           </div>
         </Form>
@@ -528,8 +567,15 @@ class UnconnectedReservationInformationForm extends Component {
   }
 }
 
+const mapStateToProps = state => ({
+  formSyncErrors: getFormSyncErrors(FormTypes.RESERVATION)(state),
+  formValues: getFormValues(FormTypes.RESERVATION)(state),
+});
+
 UnconnectedReservationInformationForm.propTypes = {
   fields: PropTypes.array.isRequired,
+  formSyncErrors: PropTypes.object,
+  formValues: PropTypes.object,
   hasPayment: PropTypes.bool.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   isEditing: PropTypes.bool.isRequired,
@@ -565,8 +611,8 @@ UnconnectedReservationInformationForm.propTypes = {
 UnconnectedReservationInformationForm = injectT(UnconnectedReservationInformationForm);  // eslint-disable-line
 
 export { UnconnectedReservationInformationForm };
-export default injectT(reduxForm({
+export default injectT(connect(mapStateToProps, null)(reduxForm({
   form: FormTypes.RESERVATION,
   enableReinitialize: true,
   validate,
-})(UnconnectedReservationInformationForm));
+})(UnconnectedReservationInformationForm)));

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.spec.js
@@ -16,6 +16,7 @@ import {
 } from './ReservationInformationForm';
 import ReservationSubmitButton from './ReservationSubmitButton';
 import { hasProducts } from 'utils/reservationUtils';
+import ReservationValidationErrors from './ReservationValidationErrors';
 
 describe('pages/reservation/reservation-information/ReservationInformationForm', () => {
   describe('validation', () => {
@@ -243,7 +244,7 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
     });
   });
 
-  describe('rendering', () => {
+  describe('rendering and methods', () => {
     const defaultProps = {
       fields: [],
       hasPayment: false,
@@ -533,13 +534,14 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
         });
 
         test('renders ReservationSubmitButton with correct props', () => {
-          const submitButton = getWrapper().find(ReservationSubmitButton);
+          const wrapper = getWrapper();
+          const instance = wrapper.instance();
+          const submitButton = wrapper.find(ReservationSubmitButton);
           expect(submitButton).toHaveLength(1);
-          expect(submitButton.prop('handleSubmit')).toBe(defaultProps.handleSubmit);
+          expect(submitButton.prop('handleFormSubmit')).toBe(instance.handleFormSubmit);
           expect(submitButton.prop('hasPayment')).toBe(hasProducts(defaultProps.resource));
           expect(submitButton.prop('isMakingReservations')).toBe(defaultProps.isMakingReservations);
           expect(submitButton.prop('needManualConfirmation')).toBe(defaultProps.resource.needManualConfirmation);
-          expect(submitButton.prop('onConfirm')).toBe(defaultProps.onConfirm);
         });
       });
 
@@ -591,12 +593,57 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
         });
 
         test('renders ReservationSubmitButton with correct props', () => {
-          const submitButton = getWrapper({ isEditing: true }).find(ReservationSubmitButton);
+          const wrapper = getWrapper({ isEditing: true });
+          const instance = wrapper.instance();
+          const submitButton = wrapper.find(ReservationSubmitButton);
           expect(submitButton).toHaveLength(1);
-          expect(submitButton.prop('handleSubmit')).toBe(defaultProps.handleSubmit);
+          expect(submitButton.prop('handleFormSubmit')).toBe(instance.handleFormSubmit);
           expect(submitButton.prop('hasPayment')).toBe(defaultProps.hasPayment);
           expect(submitButton.prop('isMakingReservations')).toBe(defaultProps.isMakingReservations);
-          expect(submitButton.prop('onConfirm')).toBe(defaultProps.onConfirm);
+        });
+      });
+    });
+
+    test('renders ReservationValidationErrors', () => {
+      const wrapper = getWrapper();
+      const instance = wrapper.instance();
+      const validationErrors = wrapper.find(ReservationValidationErrors);
+      expect(validationErrors).toHaveLength(1);
+      expect(validationErrors.prop('formErrors')).toBe(instance.state.formErrors);
+      expect(validationErrors.prop('showFormErrorList')).toBe(instance.state.showFormErrorList);
+      expect(validationErrors.prop('universalFields')).toBe(defaultProps.resource.universalField);
+    });
+
+    describe('methods', () => {
+      describe('componentDidUpdate', () => {
+        test('sets correct state when showFormErrorList is true and formValues has changed', () => {
+          const prevProps = { formValues: { foo: 'bar' } };
+          const instance = getWrapper({ formValues: { foo: 'baz' } }).instance();
+          instance.state.showFormErrorList = true;
+          instance.state.formErrors = ['foo'];
+          instance.componentDidUpdate(prevProps);
+          expect(instance.state.showFormErrorList).toBe(false);
+          expect(instance.state.formErrors).toEqual([]);
+        });
+      });
+
+      describe('handleFormSubmit', () => {
+        test('calls setState with correct params when there are form errors', () => {
+          const instance = getWrapper({ formSyncErrors: { foo: 'bar' } }).instance();
+          const spy = jest.spyOn(instance, 'setState');
+          instance.handleFormSubmit();
+          expect(spy).toHaveBeenCalledTimes(1);
+          expect(spy).toHaveBeenCalledWith({ showFormErrorList: true, formErrors: ['foo'] });
+        });
+
+        test('calls handleSubmit', () => {
+          const handleSubmit = jest.fn();
+          const instance = getWrapper({ handleSubmit }).instance();
+          handleSubmit.mockClear();
+
+          instance.handleFormSubmit();
+          expect(handleSubmit).toHaveBeenCalledTimes(1);
+          expect(handleSubmit).toHaveBeenCalledWith(defaultProps.onConfirm);
         });
       });
     });

--- a/app/pages/reservation/reservation-information/ReservationSubmitButton.js
+++ b/app/pages/reservation/reservation-information/ReservationSubmitButton.js
@@ -5,7 +5,7 @@ import { Button } from 'react-bootstrap';
 import injectT from '../../../i18n/injectT';
 
 function ReservationSubmitButton({
-  isMakingReservations, handleSubmit, hasPayment, needManualConfirmation, onConfirm, t
+  isMakingReservations, handleFormSubmit, hasPayment, needManualConfirmation, t
 }) {
   let buttonText = isMakingReservations ? t('common.saving') : t('common.save');
   if (hasPayment && !needManualConfirmation) {
@@ -16,7 +16,7 @@ function ReservationSubmitButton({
     <Button
       bsStyle="primary"
       disabled={isMakingReservations}
-      onClick={handleSubmit(onConfirm)}
+      onClick={handleFormSubmit}
       type="submit"
     >
       {buttonText}
@@ -30,10 +30,9 @@ ReservationSubmitButton.defaultProps = {
 
 ReservationSubmitButton.propTypes = {
   isMakingReservations: PropTypes.bool.isRequired,
-  handleSubmit: PropTypes.func.isRequired,
+  handleFormSubmit: PropTypes.func.isRequired,
   hasPayment: PropTypes.bool.isRequired,
   needManualConfirmation: PropTypes.bool,
-  onConfirm: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired
 };
 

--- a/app/pages/reservation/reservation-information/ReservationSubmitButton.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationSubmitButton.spec.js
@@ -6,9 +6,8 @@ import { shallowWithIntl } from 'utils/testUtils';
 describe('pages/reservation/reservation-information/ReservationSubmitButton', () => {
   const defaultProps = {
     isMakingReservations: false,
-    handleSubmit: () => {},
+    handleFormSubmit: () => {},
     hasPayment: false,
-    onConfirm: () => {}
   };
 
   function getWrapper(extraProps) {
@@ -21,7 +20,7 @@ describe('pages/reservation/reservation-information/ReservationSubmitButton', ()
       expect(button).toHaveLength(1);
       expect(button.prop('bsStyle')).toBe('primary');
       expect(button.prop('disabled')).toBe(defaultProps.isMakingReservations);
-      expect(button.prop('onClick')).toBe(defaultProps.handleSubmit(defaultProps.onConfirm));
+      expect(button.prop('onClick')).toBe(defaultProps.handleFormSubmit);
       expect(button.prop('type')).toBe('submit');
     });
 

--- a/app/pages/reservation/reservation-information/ReservationValidationErrors.js
+++ b/app/pages/reservation/reservation-information/ReservationValidationErrors.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import injectT from '../../../i18n/injectT';
+import { capitalizeFirst } from '../../../utils/textUtils';
+import { mapReservationErrors } from '../../../utils/reservationUtils';
+
+
+function ReservationValidationErrors({
+  formErrors, universalFields, showFormErrorList, t
+}) {
+  if (!showFormErrorList) {
+    return <div id="information-page-validation-and-errors" role="alert" />;
+  }
+
+  const mappedErrors = mapReservationErrors(formErrors, universalFields);
+  const errorMessages = mappedErrors.map(error => {
+    if (error.forBilling) {
+      return (
+        <li key={error.id}>
+          {`${t('ReservationForm.validation.payer.label')} `}
+          <span className="text-lowercase">{t(error.label)}</span>
+        </li>
+      );
+    }
+    // universal field has its own translations
+    if (error.id === 'universalData') {
+      return <li key={error.id}>{capitalizeFirst(error.label)}</li>;
+    }
+    return <li key={error.id}>{capitalizeFirst(t(error.label))}</li>;
+  });
+
+  return (
+    <div id="information-page-validation-and-errors" role="alert">
+      <div>
+        <p className="validation-error-label">
+          {t('ReservationProducts.validation.label')}
+        </p>
+        <ul>
+          {errorMessages}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+ReservationValidationErrors.propTypes = {
+  universalFields: PropTypes.arrayOf(PropTypes.object),
+  t: PropTypes.func.isRequired,
+  formErrors: PropTypes.arrayOf(PropTypes.string),
+  showFormErrorList: PropTypes.bool.isRequired,
+};
+
+export default injectT(ReservationValidationErrors);

--- a/app/pages/reservation/reservation-information/ReservationValidationErrors.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationValidationErrors.spec.js
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import { shallowWithIntl } from 'utils/testUtils';
+import ReservationValidationErrors from './ReservationValidationErrors';
+import { capitalizeFirst } from '../../../utils/textUtils';
+import { FIELDS } from '../../../constants/ReservationConstants';
+
+describe('pages/reservation/reservation-information/ReservationValidationErrors', () => {
+  const defaultProps = {
+    universalFields: [{
+      data: null,
+      description: 'test-description',
+      id: 3,
+      label: 'test-label',
+      name: 'test-name',
+      options: [
+        { id: 1, text: 'test-option-1' },
+        { id: 2, text: 'test-option-2' },
+        { id: 3, text: 'test-option-3' },
+      ],
+    }],
+    formErrors: ['reserverName', 'reserverEmailAddress', 'universalData', 'billingAddressStreet'],
+    showFormErrorList: true,
+  };
+
+  function getWrapper(extraProps) {
+    return shallowWithIntl(<ReservationValidationErrors {...defaultProps} {...extraProps} />);
+  }
+
+  describe('renders', () => {
+    test('only wrapping div when showFormErrorList is false', () => {
+      const wrapper = getWrapper({ showFormErrorList: false });
+      const div = wrapper.find('#information-page-validation-and-errors');
+      expect(div).toHaveLength(1);
+      expect(div.prop('role')).toBe('alert');
+      expect(div.children()).toHaveLength(0);
+    });
+
+    describe('when showFormErrorList is true', () => {
+      test('wrapping div', () => {
+        const wrapper = getWrapper();
+        const div = wrapper.find('#information-page-validation-and-errors');
+        expect(div).toHaveLength(1);
+        expect(div.prop('role')).toBe('alert');
+      });
+
+      test('empty div after wrapping div', () => {
+        const wrapper = getWrapper();
+        const div = wrapper.find('#information-page-validation-and-errors').children().find('div');
+        expect(div).toHaveLength(1);
+      });
+
+      test('validation error label', () => {
+        const wrapper = getWrapper();
+        const label = wrapper.find('p.validation-error-label');
+        expect(label).toHaveLength(1);
+        expect(label.text()).toBe('ReservationProducts.validation.label');
+      });
+
+      test('validation error list', () => {
+        const wrapper = getWrapper();
+        const list = wrapper.find('ul');
+        expect(list).toHaveLength(1);
+      });
+
+      test('validation error list items', () => {
+        const wrapper = getWrapper();
+        const listItems = wrapper.find('li');
+        expect(listItems).toHaveLength(4);
+        expect(listItems.at(0).text()).toBe(capitalizeFirst(FIELDS.RESERVER_NAME.label));
+        expect(listItems.at(1).text()).toBe(capitalizeFirst(FIELDS.RESERVER_EMAIL_ADDRESS.label));
+        expect(listItems.at(2).text()).toBe(
+          `ReservationForm.validation.payer.label ${FIELDS.BILLING_ADDRESS_STREET.label}`
+        );
+        const billingSpan = listItems.at(2).find('span');
+        expect(billingSpan).toHaveLength(1);
+        expect(billingSpan.prop('className')).toBe('text-lowercase');
+        expect(listItems.at(3).text()).toBe(capitalizeFirst(defaultProps.universalFields[0].label));
+      });
+    });
+  });
+});

--- a/app/pages/reservation/reservation-information/_reservation-information.scss
+++ b/app/pages/reservation/reservation-information/_reservation-information.scss
@@ -2,40 +2,72 @@
   form {
     padding-bottom: 15px;
   }
+
   .form-controls {
     text-align: right;
   }
+
   .btn {
     margin-left: 15px;
-   @media (max-width: $screen-xs-max){
-    margin-bottom: 8px;
-   }
+
+    @media (max-width: $screen-xs-max) {
+      margin-bottom: 8px;
+    }
   }
+
   .select-input {
     border: 2px solid #000000;
     margin-top: 7px;
 
-    @media(max-width: $screen-md-min){
+    @media(max-width: $screen-md-min) {
       width: 100%;
     }
   }
 
 
-  .has-error{
+  .has-error {
+
     .control-label,
     .help-block,
-    label{
+    label {
       color: $varaamo-high-contrast-red;
     }
-    .form-control{
+
+    .form-control {
       border-color: $varaamo-high-contrast-red;
     }
-    .terms-checkbox-field-link{
+
+    .terms-checkbox-field-link {
       color: $blue;
     }
   }
 
   .wrapped-text a {
     color: $blue;
+  }
+
+  #information-page-validation-and-errors {
+    color: $varaamo-high-contrast-red;
+    display: flex;
+    justify-content: flex-end;
+
+    .validation-error-label {
+      text-align: left;
+    }
+
+    @media (max-width: $screen-xs-max) {
+      text-align: left;
+      justify-content: flex-start;
+    }
+
+    p {
+      margin-top: 12px;
+      margin-bottom: 8px;
+    }
+
+    ul {
+      text-align: start;
+      padding-left: 18px;
+    }
   }
 }

--- a/app/utils/__tests__/reservationUtils.spec.js
+++ b/app/utils/__tests__/reservationUtils.spec.js
@@ -31,10 +31,12 @@ import {
   getReservationCustomerGroupName,
   isManuallyConfirmedWithOrderAllowed,
   normalizeUniversalFieldOptions,
+  mapReservationErrors,
 } from 'utils/reservationUtils';
 import { buildAPIUrl, getHeadersCreator } from '../apiUtils';
 import Product from '../fixtures/Product';
 import { getLocalizedFieldValue } from '../languageUtils';
+import { FIELDS } from '../../constants/ReservationConstants';
 
 jest.mock('../languageUtils', () => ({
   getLocalizedFieldValue: jest.fn(() => 'test-localized-value'),
@@ -794,6 +796,39 @@ describe('Utils: reservationUtils', () => {
         },
       };
       expect(returnValues).toEqual([expectedValues]);
+    });
+  });
+
+  describe('mapReservationErrors', () => {
+    const universalFields = [UniversalField.build()];
+    describe('creates correct list of reservation errors', () => {
+      test('when reservation has no errors', () => {
+        const errors = [];
+        expect(mapReservationErrors(errors, universalFields)).toEqual([]);
+      });
+
+      test('when universalfield has an error', () => {
+        const errors = ['universalData'];
+        expect(mapReservationErrors(errors, universalFields)).toEqual([{
+          id: 'universalData',
+          label: universalFields[0].label,
+          forBilling: false,
+          order: 100
+        }]);
+      });
+
+      test('when reservation has multiple errors', () => {
+        const errors = ['universalData', FIELDS.RESERVER_EMAIL_ADDRESS.id, FIELDS.BILLING_PHONE_NUMBER.id];
+        expect(mapReservationErrors(errors, universalFields)).toEqual([
+          FIELDS.RESERVER_EMAIL_ADDRESS, FIELDS.BILLING_PHONE_NUMBER,
+          {
+            id: 'universalData',
+            label: universalFields[0].label,
+            forBilling: false,
+            order: 100
+          },
+        ]);
+      });
     });
   });
 });

--- a/app/utils/__tests__/textUtils.spec.js
+++ b/app/utils/__tests__/textUtils.spec.js
@@ -1,4 +1,4 @@
-import { cleanseNamedLinks, createTextSnippet } from 'utils/textUtils';
+import { cleanseNamedLinks, createTextSnippet, capitalizeFirst } from 'utils/textUtils';
 
 describe('Utils: textUtils', () => {
   describe('cleanseNamedLinks', () => {
@@ -24,6 +24,15 @@ describe('Utils: textUtils', () => {
     test('if given string is longer than given length, returns string of given length with added dots', () => {
       const testString = 'this is a test string';
       expect(createTextSnippet(testString, 4)).toEqual('this...');
+    });
+  });
+
+  describe('capitalizeFirst', () => {
+    test('returns correct capitalized string', () => {
+      expect(capitalizeFirst('test')).toEqual('Test');
+      expect(capitalizeFirst('test string')).toEqual('Test string');
+      expect(capitalizeFirst('Test String')).toEqual('Test String');
+      expect(capitalizeFirst('tEST sTRING')).toEqual('TEST sTRING');
     });
   });
 });

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -11,6 +11,7 @@ import moment from 'moment';
 import { PhoneNumberUtil } from 'google-libphonenumber';
 
 import constants from 'constants/AppConstants';
+import { FIELDS } from 'constants/ReservationConstants';
 import { buildAPIUrl, getHeadersCreator } from './apiUtils';
 import { getLocalizedFieldValue } from './languageUtils';
 
@@ -412,6 +413,32 @@ function normalizeUniversalFieldOptions(universalField, resource) {
   }, []);
 }
 
+/**
+ * Returns mapped and sorted reservation form errors from the given errors array.
+ * @param {Object[]} errors reservation form errors
+ * @param {Object[]} universalFields universal fields in this form
+ * @returns {Object[]} mapped and sorted reservation form errors
+ */
+function mapReservationErrors(errors, universalFields) {
+  const mappedErrors = errors.map((error, index) => {
+    // Note: only one universal field per resource is supported currently.
+    if (error === 'universalData') {
+      return {
+        id: error, label: universalFields[0].label, forBilling: false, order: 100 + index
+      };
+    }
+    const errorField = Object.values(FIELDS).find(field => field.id === error);
+    if (errorField) {
+      return errorField;
+    }
+    return {
+      id: error, label: error, forBilling: false, order: 100 + index
+    };
+  });
+
+  return mappedErrors.sort((a, b) => a.order - b.order);
+}
+
 export {
   combine,
   isStaffEvent,
@@ -437,4 +464,5 @@ export {
   getReservationCustomerGroupName,
   isManuallyConfirmedWithOrderAllowed,
   normalizeUniversalFieldOptions,
+  mapReservationErrors,
 };

--- a/app/utils/textUtils.js
+++ b/app/utils/textUtils.js
@@ -45,7 +45,17 @@ function createTextSnippet(text, maxCharacters) {
   return `${text.substring(0, maxCharacters)}...`;
 }
 
+/**
+ * Capitalizes the first letter of a given string.
+ * @param {string} text
+ * @returns {string} capitalized string
+ */
+function capitalizeFirst(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 export {
+  capitalizeFirst,
   cleanseNamedLinks,
   createTextSnippet,
 };


### PR DESCRIPTION
# Form level error list for clients' reservation form

## When reservation page form has errors, they are listed after submit button for user to see.

### [Related Trello card](https://trello.com/c/AiqvUgQ2)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### reservation page form level error listing
 1. app/constants/ReservationConstants.js 
     * added reservation form fields to constants
   
 2. app/pages/reservation/reservation-information/ReservationInformationForm.js
     * added state handling for form errors
     * added new handleFormSubmit function to also handle error state handling as well as calling original handleSubmit
     * refactored form fields to use new form field constants instead of directly using fields' string values
     * added validation error component below submit button
    
 3. app/pages/reservation/reservation-information/ReservationSubmitButton.js
     * changed onClick to use new handleFormSubmit function

 4. app/pages/reservation/reservation-information/ReservationValidationErrors.js
     * new component that handles showing reservation form error list

 5. app/utils/reservationUtils.js
     * added function mapReservationErrors to handle mapping and sorting reservation form errors

 6. app/utils/textUtils.js
     * added function capitalizeFirst
