### PR TITLE
Added reservation contact info purpose text

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -60,7 +60,7 @@
   "common.companyLabel": "Company",
   "common.confirmCashPayment": "Approve cash payment",
   "common.confirmed": "Approved",
-  "common.contactPurposeHelp": "Contact information can be used to contact you",
+  "common.contactPurposeHelp": "The contact information requested here is needed for communication related to the reservation. It will not be used for marketing purposes.",
   "common.continue": "Continue",
   "common.denied": "Denied",
   "common.eventDescriptionLabel": "Description of the event",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -60,7 +60,7 @@
   "common.companyLabel": "Yritys",
   "common.confirmCashPayment": "Hyväksy käteismaksu",
   "common.confirmed": "Hyväksytty",
-  "common.contactPurposeHelp": "Yhteystietoa voidaan käyttää yhteydenottoa varten",
+  "common.contactPurposeHelp": "Tässä kysyttyjä yhteystietoja tarvitaan varaamiseen liittyvään viestintään. Niitä ei käytetä markkinointiin.",
   "common.continue": "Jatka",
   "common.denied": "Hylätty",
   "common.eventDescriptionLabel": "Tilaisuuden kuvaus",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -60,7 +60,7 @@
   "common.companyLabel": "Företag",
   "common.confirmCashPayment": "Godkänn kontant betalning",
   "common.confirmed": "Godkänd",
-  "common.contactPurposeHelp": "kontaktuppgifterna kan användas för att kontakta dig",
+  "common.contactPurposeHelp": "De kontaktuppgifter som efterfrågas här behövs för kommunikation relaterad till bokningen. De kommer inte att användas för marknadsföring.",
   "common.continue": "Fortsätt",
   "common.denied": "Ej godkänd",
   "common.eventDescriptionLabel": "Beskrivning av evenemanget",

--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -169,12 +169,15 @@ class ReservationInformation extends Component {
 
   renderInfoTexts = () => {
     const { resource, t } = this.props;
-    if (!resource.needManualConfirmation) return null;
-
     return (
       <div className="app-ReservationInformation__info-texts">
-        <p>{t('ConfirmReservationModal.priceInfo')}</p>
-        <p>{t('ConfirmReservationModal.formInfo')}</p>
+        <p>{t('common.contactPurposeHelp')}</p>
+        {resource.needManualConfirmation && (
+          <React.Fragment>
+            <p>{t('ConfirmReservationModal.priceInfo')}</p>
+            <p>{t('ConfirmReservationModal.formInfo')}</p>
+          </React.Fragment>
+        )}
       </div>
     );
   }

--- a/app/pages/reservation/reservation-information/ReservationInformation.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.spec.js
@@ -46,21 +46,24 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
     return shallowWithIntl(<ReservationInformation {...defaultProps} {...extraProps} />);
   }
 
-  test('renders info texts when needManualConfirmation is true', () => {
+  test('renders correct info texts when needManualConfirmation is true', () => {
     const resource = Resource.build({
       needManualConfirmation: true,
     });
     const infoTexts = getWrapper({ resource }).find('.app-ReservationInformation__info-texts');
     expect(infoTexts).toHaveLength(1);
+    expect(infoTexts.text()).toContain('common.contactPurposeHelp');
     expect(infoTexts.text()).toContain('ConfirmReservationModal.priceInfo');
+    expect(infoTexts.text()).toContain('ConfirmReservationModal.formInfo');
   });
 
-  test('does not render info texts when needManualConfirmation is false', () => {
+  test('renders correct info texts when needManualConfirmation is false', () => {
     const resource = Resource.build({
       needManualConfirmation: false,
     });
     const infoTexts = getWrapper({ resource }).find('.app-ReservationInformation__info-texts');
-    expect(infoTexts).toHaveLength(0);
+    expect(infoTexts).toHaveLength(1);
+    expect(infoTexts.text()).toContain('common.contactPurposeHelp');
   });
 
   test('renders an ReservationInformationForm element', () => {

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -324,7 +324,6 @@ class UnconnectedReservationInformationForm extends Component {
             'text',
             t(FIELDS.RESERVER_PHONE_NUMBER.label),
             { autoComplete: 'tel' },
-            t('common.contactPurposeHelp'),
           )}
           {this.renderField(
             FIELDS.RESERVER_EMAIL_ADDRESS.id,
@@ -332,7 +331,6 @@ class UnconnectedReservationInformationForm extends Component {
             'email',
             t(FIELDS.RESERVER_EMAIL_ADDRESS.label),
             { autoComplete: 'email' },
-            t('common.contactPurposeHelp'),
           )}
           {resource.universalField && resource.universalField.length > 0
             && this.renderUniversalFields()


### PR DESCRIPTION
# Reservation contact info purpose text

## Added reservation contact info purpose text to reservation page top and  removed reservation phone and email field purpose texts

### [Related Trello card](https://trello.com/c/v28DwnNO)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Reservation contact purpose info text
 1. app/pages/reservation/reservation-information/ReservationInformation.js
     * Added new reservation contact info purpose text to be always visible
   
 2. app/pages/reservation/reservation-information/ReservationInformationForm.js
     * Removed contact purpose help text from phone and email fields