### PR TITLE
Added support for reservation private event field

### DIFF
--- a/app/constants/ReservationConstants.js
+++ b/app/constants/ReservationConstants.js
@@ -42,18 +42,21 @@ export const FIELDS = {
   REQUIRE_WORKSTATION: {
     id: 'requireWorkstation', label: 'common.requireWorkstationLabel', forBilling: false, order: 20
   },
+  PRIVATE_EVENT: {
+    id: 'privateEvent', label: 'common.privateEventLabel', forBilling: false, order: 21
+  },
   COMMENTS: {
-    id: 'comments', label: 'common.commentsLabel', forBilling: false, order: 21
+    id: 'comments', label: 'common.commentsLabel', forBilling: false, order: 22
   },
   RESERVATION_EXTRA_QUESTIONS: {
-    id: 'reservationExtraQuestions', label: 'common.additionalInfo.label', forBilling: false, order: 22
+    id: 'reservationExtraQuestions', label: 'common.additionalInfo.label', forBilling: false, order: 23
   },
   // terms fields are special, they have common starting label and unique end link label
   TERMS_AND_CONDITIONS: {
-    id: 'termsAndConditions', label: 'ReservationInformationForm.termsAndConditionsLink', forBilling: false, order: 23
+    id: 'termsAndConditions', label: 'ReservationInformationForm.termsAndConditionsLink', forBilling: false, order: 24
   },
   PAYMENT_TERMS_AND_CONDITIONS: {
-    id: 'paymentTermsAndConditions', label: 'ReservationInformationForm.paymentTermsAndConditionsLink', forBilling: false, order: 24
+    id: 'paymentTermsAndConditions', label: 'ReservationInformationForm.paymentTermsAndConditionsLink', forBilling: false, order: 25
   },
   // billing fields
   BILLING_FIRST_NAME: {

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -84,6 +84,7 @@
   "common.priceLabel": "Price",
   "common.priceTotalLabel": "Total price",
   "common.priceWithVAT": "{price}€ (inc. vat. {vat}%)",
+  "common.privateEventLabel": "Private event",
   "common.proceedToPayment": "Proceed to payment",
   "common.proceedingToPayment": "Proceeding to payment...",
   "common.requested": "Waiting for processing",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -84,6 +84,7 @@
   "common.priceLabel": "Hinta",
   "common.priceTotalLabel": "Hinta yhteensä",
   "common.priceWithVAT": "{price}€ (sis. alv. {vat}%)",
+  "common.privateEventLabel": "Yksityinen tilaisuus",
   "common.proceedToPayment": "Siirry maksamaan",
   "common.proceedingToPayment": "Siirrytään maksamaan...",
   "common.requested": "Odottaa käsittelyä",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -84,6 +84,7 @@
   "common.priceLabel": "Pris",
   "common.priceTotalLabel": "Total pris",
   "common.priceWithVAT": "{price}€ (inkl. mons {vat}%)",
+  "common.privateEventLabel": "Privat evenemang",
   "common.proceedToPayment": "Fortsätt till betalning",
   "common.proceedingToPayment": "Fortsätter till betalning...",
   "common.requested": "Behandlas",

--- a/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
+++ b/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
@@ -228,6 +228,13 @@ class ReservationConfirmation extends Component {
                 t('common.yes'),
                 reservation.requireWorkstation
               )}
+            {reservation.privateEvent
+              && this.renderField(
+                'privateEvent',
+                t('common.privateEventLabel'),
+                t('common.yes'),
+                reservation.privateEvent
+              )}
             {reservation.comments
               && this.renderField('comments', t('common.commentsLabel'), reservation.comments)}
             {reservation.reserverAddressStreet

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -491,6 +491,16 @@ class UnconnectedReservationInformationForm extends Component {
             true
           )}
           {this.renderField(
+            FIELDS.PRIVATE_EVENT.id,
+            'privateEvent',
+            'checkbox',
+            t(FIELDS.PRIVATE_EVENT.label),
+            {},
+            null,
+            null,
+            true
+          )}
+          {this.renderField(
             FIELDS.COMMENTS.id,
             'comments',
             'textarea',

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -244,6 +244,8 @@ class UnconnectedReservationEditForm extends Component {
            && this.renderInfoRow(t('common.requireAssistanceLabel'), reservation.requireAssistance ? t('common.yes') : t('common.no'))}
         {!(reservation.requireWorkstation === undefined)
            && this.renderInfoRow(t('common.requireWorkstationLabel'), reservation.requireWorkstation ? t('common.yes') : t('common.no'))}
+        {!(reservation.privateEvent === undefined)
+           && this.renderInfoRow(t('common.privateEventLabel'), reservation.privateEvent ? t('common.yes') : t('common.no'))}
         {this.renderInfoRow(t('common.additionalInfo.label'), reservation.reservationExtraQuestions)}
         {isAdmin && !reservationIsEditable && this.renderStaticInfoRow('comments')}
         {(orderLine && price) && (

--- a/app/shared/modals/reservation-info/ReservationEditForm.spec.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.spec.js
@@ -228,6 +228,22 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
         });
       });
 
+      describe('private event', () => {
+        test('is rendered if reservation supports it', () => {
+          const userReservation = Reservation.build({
+            privateEvent: false
+          });
+          expect(getData({ reservation: userReservation })).toContain('common.privateEventLabel');
+        });
+
+        test('is not rendered if reservation doesnt support it', () => {
+          const userReservation = Reservation.build({
+            privateEvent: undefined
+          });
+          expect(getData({ reservation: userReservation })).not.toContain('common.privateEventLabel');
+        });
+      });
+
       describe('reservation extra questions', () => {
         test('is rendered if reservation supports it', () => {
           const userReservation = Reservation.build({

--- a/app/shared/reservation-confirmation/ReservationForm.js
+++ b/app/shared/reservation-confirmation/ReservationForm.js
@@ -311,6 +311,16 @@ class UnconnectedReservationForm extends Component {
             null,
             true
           )}
+          {this.renderField(
+            'privateEvent',
+            'privateEvent',
+            'checkbox',
+            t('common.privateEventLabel'),
+            {},
+            null,
+            null,
+            true
+          )}
           {includes(this.props.fields, 'reservationExtraQuestions') && (
             <Well>
               <p id="additional-info-heading">{t('common.additionalInfo.heading')}</p>


### PR DESCRIPTION
# Support for reservation private event field

## Added reservation private event to reservation forms and reservation modals

### [Related Trello card](https://trello.com/c/wFZmSDfQ)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### reservation private event field
 1. app/constants/ReservationConstants.js
     * added constant for private event field
   
 2. app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
     * added reservation private event field to reservation confirm page
    
 3. app/pages/reservation/reservation-information/ReservationInformationForm.js
     * added reservation private event field to reservation page form

 4. app/shared/modals/reservation-info/ReservationEditForm.js
     * added reservation private event field to reservation info modals

 5. app/shared/reservation-confirmation/ReservationForm.js
     * added reservation private event field to admin reservation modal form
