### PR TITLE
Added copy reserver info to payer info button

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -323,6 +323,8 @@
   "ReservationInfoModal.saveComment": "Save comment",
   "ReservationInfoModal.title": "Reservation information.",
   "ReservationInformationForm.cancelEdit": "Cancel edit",
+  "ReservationInformationForm.copyConfirmed": "✓ Copied!",
+  "ReservationInformationForm.copyInfoButtonLabel": "Copy reserver info to payer info",
   "ReservationInformationForm.reserverInformationTitle": "Reserver information",
   "ReservationInformationForm.eventInformationTitle": "Event information",
   "ReservationInformationForm.paymentTermsAndConditionsLink": "the payment terms of the premises",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -323,6 +323,8 @@
   "ReservationInfoModal.saveComment": "Tallenna kommentti",
   "ReservationInfoModal.title": "Varauksen tiedot",
   "ReservationInformationForm.cancelEdit": "Keskeytä muokkaus",
+  "ReservationInformationForm.copyConfirmed": "✓ Kopioitu!",
+  "ReservationInformationForm.copyInfoButtonLabel": "Kopioi varaajan tiedot maksajan tietoihin",
   "ReservationInformationForm.reserverInformationTitle": "Varaajan tiedot",
   "ReservationInformationForm.eventInformationTitle": "Tilaisuuden tiedot",
   "ReservationInformationForm.paymentTermsAndConditionsLink": "tilan maksuehdot",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -325,6 +325,8 @@
   "ReservationInfoModal.saveComment": "Spara kommentar",
   "ReservationInfoModal.title": "Uppgifter om bokningen",
   "ReservationInformationForm.cancelEdit": "Avbryt bearbetningen",
+  "ReservationInformationForm.copyConfirmed": "✓ Kopierat!",
+  "ReservationInformationForm.copyInfoButtonLabel": "Kopiera beställarinfo till betalningsinfo",
   "ReservationInformationForm.reserverInformationTitle": "Beställarens uppgifter",
   "ReservationInformationForm.eventInformationTitle": "Evenemangets uppgifter",
   "ReservationInformationForm.paymentTermsAndConditionsLink": "betalningsvillkoren",

--- a/app/pages/reservation/reservation-information/_reservation-information.scss
+++ b/app/pages/reservation/reservation-information/_reservation-information.scss
@@ -24,6 +24,33 @@
     }
   }
 
+  .payment-info-heading-container {
+    #payment-info-heading {
+      margin-top: 0;
+    }
+
+    #copy-info-button {
+      margin-left: 0;
+      white-space: normal;
+
+      @media(max-width: $screen-md-min) {
+        width: 100%;
+      }
+    }
+
+    #copied-info-status {
+      margin-left: 8px;
+    }
+
+    #copied-info-status.hide-info {
+      opacity: 0;
+    }
+
+    .align-right {
+      text-align: right;
+    }
+  }
+
 
   .has-error {
 


### PR DESCRIPTION
# Copy reserver info to payer info button

When reservation has payments, reservation info form page renders a copy button which copies certain reserver info fields to payer info fields

[Related Trello card](https://trello.com/c/150xSmAM)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Copy button handling
 1. app/pages/reservation/reservation-information/ReservationInformationForm.js 
     * added reservation info copy button and its success status message
     * copy button copies reserver name, phone, email, street, zip and city values to payer info fields