### PR TITLE
Fixed reservation payment terms false error report

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -147,7 +147,7 @@ class ReservationInformation extends Component {
     return {};
   }
 
-  getRequiredFormFields(resource, termsAndConditions) {
+  getRequiredFormFields(resource, termsAndConditions, paymentTermsAndConditions) {
     const requiredFormFields = [...resource.requiredReservationExtraFields.map(
       field => camelCase(field)
     )];
@@ -160,7 +160,7 @@ class ReservationInformation extends Component {
       requiredFormFields.push('termsAndConditions');
     }
 
-    if (hasProducts(resource)) {
+    if (paymentTermsAndConditions) {
       requiredFormFields.push('paymentTermsAndConditions');
     }
 
@@ -223,7 +223,8 @@ class ReservationInformation extends Component {
             openResourcePaymentTermsModal={openResourcePaymentTermsModal}
             openResourceTermsModal={openResourceTermsModal}
             paymentTermsAndConditions={paymentTermsAndConditions}
-            requiredFields={this.getRequiredFormFields(resource, termsAndConditions)}
+            requiredFields={this.getRequiredFormFields(
+              resource, termsAndConditions, paymentTermsAndConditions)}
             resource={resource}
             termsAndConditions={termsAndConditions}
             user={user}

--- a/app/pages/reservation/reservation-information/ReservationInformation.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.spec.js
@@ -374,6 +374,17 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
       expect(actual).toEqual(['someField1', 'someField2', 'termsAndConditions']);
     });
 
+    test('returns paymentTermsAndConditions if they are defined', () => {
+      const resource = Resource.build({
+        paymentTermsAndConditions: 'payment terms and conditions'
+      });
+      const instance = getWrapper().instance();
+      const actual = instance.getRequiredFormFields(
+        resource, undefined, resource.paymentTermsAndConditions);
+
+      expect(actual).toEqual(['paymentTermsAndConditions']);
+    });
+
     test('returns required form field and universalData if resource has universalField with content', () => {
       let resource = Resource.build({
         requiredReservationExtraFields: ['some_field_1', 'some_field_2'],


### PR DESCRIPTION
# Reservation payment terms false error report on submit error check

Payment terms are no longer considered a required field simply when a reservation has payments but instead only when payment terms are defined for the resource in question.

[Related Trello card](https://trello.com/c/v6iHDbnv)

-----------------------------------------------------------------------------------------------
## Breakdown:

### Payment terms false error report fix
 1. app/pages/reservation/reservation-information/ReservationInformation.js
     * include payment terms as a required field when resource has payment terms defined instead of including payment terms based on whether reservation has payments