### PR TITLE
Fixed a false payment terms required error

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -147,7 +147,8 @@ class ReservationInformation extends Component {
     return {};
   }
 
-  getRequiredFormFields(resource, termsAndConditions, paymentTermsAndConditions) {
+  getRequiredFormFields(
+    resource, termsAndConditions, paymentTermsAndConditions, hasPayments = false) {
     const requiredFormFields = [...resource.requiredReservationExtraFields.map(
       field => camelCase(field)
     )];
@@ -160,7 +161,7 @@ class ReservationInformation extends Component {
       requiredFormFields.push('termsAndConditions');
     }
 
-    if (paymentTermsAndConditions) {
+    if (paymentTermsAndConditions && hasPayments) {
       requiredFormFields.push('paymentTermsAndConditions');
     }
 
@@ -224,7 +225,7 @@ class ReservationInformation extends Component {
             openResourceTermsModal={openResourceTermsModal}
             paymentTermsAndConditions={paymentTermsAndConditions}
             requiredFields={this.getRequiredFormFields(
-              resource, termsAndConditions, paymentTermsAndConditions)}
+              resource, termsAndConditions, paymentTermsAndConditions, hasPayment(order))}
             resource={resource}
             termsAndConditions={termsAndConditions}
             user={user}

--- a/app/pages/reservation/reservation-information/ReservationInformation.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.spec.js
@@ -374,13 +374,26 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
       expect(actual).toEqual(['someField1', 'someField2', 'termsAndConditions']);
     });
 
-    test('returns paymentTermsAndConditions if they are defined', () => {
+    test('does not return paymentTermsAndConditions if they are defined but reservation has no payments', () => {
       const resource = Resource.build({
         paymentTermsAndConditions: 'payment terms and conditions'
       });
       const instance = getWrapper().instance();
+      const hasPayments = false;
       const actual = instance.getRequiredFormFields(
-        resource, undefined, resource.paymentTermsAndConditions);
+        resource, undefined, resource.paymentTermsAndConditions, hasPayments);
+
+      expect(actual).toEqual([]);
+    });
+
+    test('returns paymentTermsAndConditions if they are defined and reservation has payments', () => {
+      const resource = Resource.build({
+        paymentTermsAndConditions: 'payment terms and conditions'
+      });
+      const instance = getWrapper().instance();
+      const hasPayments = true;
+      const actual = instance.getRequiredFormFields(
+        resource, undefined, resource.paymentTermsAndConditions, hasPayments);
 
       expect(actual).toEqual(['paymentTermsAndConditions']);
     });


### PR DESCRIPTION
# Fixed a false payment terms required error

Reservation payment terms are required only when payment terms are defined and the reservation has payments

[Related Trello card](https://trello.com/c/v6iHDbnv)

-----------------------------------------------------------------------------------------------
## Breakdown:

### Payment terms required fix
 1. app/pages/reservation/reservation-information/ReservationInformation.js
     * payment terms are required only when payment terms are defined AND the reservation has payments