### PR TITLE
Changed reserver id to only refer to business id

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -91,7 +91,7 @@
   "common.reservationTimeLabel": "Time and date of the reservation",
   "common.reserverAddressLabel": "Address",
   "common.reserverEmailAddressLabel": "E-mail",
-  "common.reserverIdLabel": "Business ID / social security number",
+  "common.reserverIdLabel": "Business ID",
   "common.reserverNameLabel": "The person making the reservation / lessee",
   "common.reserverPhoneNumberLabel": "Phone",
   "common.resourceLabel": "Premises",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -91,7 +91,7 @@
   "common.reservationTimeLabel": "Varauksen ajankohta",
   "common.reserverAddressLabel": "Osoite",
   "common.reserverEmailAddressLabel": "Sähköposti",
-  "common.reserverIdLabel": "Y-tunnus / henkilötunnus",
+  "common.reserverIdLabel": "Y-tunnus",
   "common.reserverNameLabel": "Varaaja / vuokraaja",
   "common.reserverPhoneNumberLabel": "Puhelin",
   "common.resourceLabel": "Tila",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -91,7 +91,7 @@
   "common.reservationTimeLabel": "Tidpunkt för bokning",
   "common.reserverAddressLabel": "Adress",
   "common.reserverEmailAddressLabel": "E-post",
-  "common.reserverIdLabel": "FO-nummer / personbeteckning",
+  "common.reserverIdLabel": "FO-nummer",
   "common.reserverNameLabel": "Bokare / hyrestagare",
   "common.reserverPhoneNumberLabel": "Telefon",
   "common.resourceLabel": "Utrymme",

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -352,7 +352,7 @@ class UnconnectedReservationInformationForm extends Component {
             'reserverId',
             'text',
             t(FIELDS.RESERVER_ID.label),
-            { placeholder: t('common.reserverIdLabel') }
+            {}
           )}
           {this.renderField(
             FIELDS.RESERVER_PHONE_NUMBER.id,


### PR DESCRIPTION
# Changed reserver ID to only refer to business ID

Changes:
- reservation info/form reserver id label now only refers to business id, instead of being a shared field for business id and social security number
- removed reservation form reserver id field's placeholder text

[Related Trello card](https://trello.com/c/PUuq11Rb)