### PR TITLE
Changed react bootstrap and lodash imports

### DIFF
--- a/app/pages/home/HomePage.js
+++ b/app/pages/home/HomePage.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Button, Col, Row } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
+import Col from 'react-bootstrap/lib/Col';
+import Row from 'react-bootstrap/lib/Row';
 import Loader from 'react-loader';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/pages/manage-reservations/ManageReservationsPage.js
+++ b/app/pages/manage-reservations/ManageReservationsPage.js
@@ -2,7 +2,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'react-loader';
-import { Col, Grid, Row } from 'react-bootstrap';
+import Col from 'react-bootstrap/lib/Col';
+import Grid from 'react-bootstrap/lib/Grid';
+import Row from 'react-bootstrap/lib/Row';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';

--- a/app/pages/manage-reservations/dropdown-action/ManageReservationsDropdown.js
+++ b/app/pages/manage-reservations/dropdown-action/ManageReservationsDropdown.js
@@ -1,7 +1,8 @@
 
 
 import React from 'react';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
+import DropdownButton from 'react-bootstrap/lib/DropdownButton';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
 import PropTypes from 'prop-types';
 
 import constants from 'constants/AppConstants';

--- a/app/pages/manage-reservations/filters/ManageReservationsFilters.js
+++ b/app/pages/manage-reservations/filters/ManageReservationsFilters.js
@@ -1,9 +1,10 @@
 
-import { get } from 'lodash';
+import get from 'lodash/get';
 import React from 'react';
-import {
-  Button, Col, Grid, Row
-} from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
+import Col from 'react-bootstrap/lib/Col';
+import Grid from 'react-bootstrap/lib/Grid';
+import Row from 'react-bootstrap/lib/Row';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import moment from 'moment';

--- a/app/pages/manage-reservations/filters/filterUtils.js
+++ b/app/pages/manage-reservations/filters/filterUtils.js
@@ -1,5 +1,6 @@
 
-import { isEmpty, omit } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import omit from 'lodash/omit';
 import moment from 'moment';
 
 import constants from 'constants/AppConstants';

--- a/app/pages/manage-reservations/inputs/SelectField.js
+++ b/app/pages/manage-reservations/inputs/SelectField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ControlLabel, FormGroup } from 'react-bootstrap';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Select from 'react-select';
 
 import injectT from '../../../i18n/injectT';

--- a/app/pages/manage-reservations/inputs/ToggleField.js
+++ b/app/pages/manage-reservations/inputs/ToggleField.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ControlLabel } from 'react-bootstrap';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import Toggle from 'react-toggle';
 
 function ToggleField({

--- a/app/pages/manage-reservations/list/ManageReservationsList.js
+++ b/app/pages/manage-reservations/list/ManageReservationsList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from 'react-bootstrap';
+import Table from 'react-bootstrap/lib/Table';
 import PropTypes from 'prop-types';
 
 import injectT from '../../../i18n/injectT';

--- a/app/pages/manage-reservations/list/ReservationDataRow.js
+++ b/app/pages/manage-reservations/list/ReservationDataRow.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/app/pages/manage-reservations/manageReservationsPageUtils.js
+++ b/app/pages/manage-reservations/manageReservationsPageUtils.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import constants from 'constants/AppConstants';
 import { canUserModifyReservation } from 'utils/reservationUtils';

--- a/app/pages/reservation/reservation-details/ReservationDetails.js
+++ b/app/pages/reservation/reservation-details/ReservationDetails.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Well } from 'react-bootstrap';
+import Well from 'react-bootstrap/lib/Well';
 import moment from 'moment';
 
 import injectT from '../../../i18n/injectT';

--- a/app/pages/reservation/reservation-information/ReservationSubmitButton.js
+++ b/app/pages/reservation/reservation-information/ReservationSubmitButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
 
 import injectT from '../../../i18n/injectT';
 

--- a/app/pages/reservation/reservation-products/ReservationProducts.js
+++ b/app/pages/reservation/reservation-products/ReservationProducts.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Button, Col, Row
-} from 'react-bootstrap';
-import { isEmpty } from 'lodash';
+import Button from 'react-bootstrap/lib/Button';
+import Col from 'react-bootstrap/lib/Col';
+import Row from 'react-bootstrap/lib/Row';
+import isEmpty from 'lodash/isEmpty';
 import Loader from 'react-loader';
 
 import injectT from '../../../i18n/injectT';

--- a/app/pages/reservation/reservation-products/extra-products/ExtraProducts.js
+++ b/app/pages/reservation/reservation-products/extra-products/ExtraProducts.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from 'react-bootstrap';
+import Table from 'react-bootstrap/lib/Table';
 
 import injectT from '../../../../i18n/injectT';
 import { PRODUCT_TYPES } from '../ReservationProductsUtils';

--- a/app/pages/reservation/reservation-products/extra-products/QuantityInput.js
+++ b/app/pages/reservation/reservation-products/extra-products/QuantityInput.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Glyphicon } from 'react-bootstrap';
+import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 
 import injectT from '../../../../i18n/injectT';
 

--- a/app/pages/reservation/reservation-products/mandatory-products/MandatoryProducts.js
+++ b/app/pages/reservation/reservation-products/mandatory-products/MandatoryProducts.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Checkbox, Table, Well } from 'react-bootstrap';
+import Checkbox from 'react-bootstrap/lib/Checkbox';
+import Table from 'react-bootstrap/lib/Table';
+import Well from 'react-bootstrap/lib/Well';
 
 import injectT from '../../../../i18n/injectT';
 import MandatoryProductTableRow from './MandatoryProductTableRow';

--- a/app/pages/reservation/reservation-products/product-time-slots/ProductTimeSlotPrices.js
+++ b/app/pages/reservation/reservation-products/product-time-slots/ProductTimeSlotPrices.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Panel } from 'react-bootstrap';
+import Panel from 'react-bootstrap/lib/Panel';
 
 import { getPrettifiedPeriodUnits } from 'utils/timeUtils';
 import { getTimeSlotMinMaxPrices, PRODUCT_PRICE_TYPES } from '../ReservationProductsUtils';

--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -12,7 +12,7 @@ import Col from 'react-bootstrap/lib/Col';
 import Panel from 'react-bootstrap/lib/Panel';
 import Lightbox from 'lightbox-react';
 import 'lightbox-react/style.css';
-import { Button } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
 
 import { addNotification } from 'actions/notificationsActions';
 import { fetchResource } from 'actions/resourceActions';

--- a/app/pages/user-reservations/reservation-list/reservationListSelector.js
+++ b/app/pages/user-reservations/reservation-list/reservationListSelector.js
@@ -1,5 +1,7 @@
 
-import { filter, orderBy, values } from 'lodash';
+import filter from 'lodash/filter';
+import orderBy from 'lodash/orderBy';
+import values from 'lodash/values';
 import { createSelector, createStructuredSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';

--- a/app/resource-outlook-linker/reducer.js
+++ b/app/resource-outlook-linker/reducer.js
@@ -1,8 +1,6 @@
 import Immutable from 'seamless-immutable';
-import {
-  omit,
-  reduce,
-} from 'lodash';
+import omit from 'lodash/omit';
+import reduce from 'lodash/reduce';
 
 import {
   actionTypes

--- a/app/shared/form-fields/TermsField.js
+++ b/app/shared/form-fields/TermsField.js
@@ -4,7 +4,7 @@ import Col from 'react-bootstrap/lib/Col';
 import RBCheckbox from 'react-bootstrap/lib/Checkbox';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import HelpBlock from 'react-bootstrap/lib/HelpBlock';
-import { Button } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
 
 function TermsField({
   input, label, labelLink, meta, onClick, isRequired

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -11,7 +11,7 @@ import FormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Well from 'react-bootstrap/lib/Well';
 import { Field, Fields, reduxForm } from 'redux-form';
-import { Row } from 'react-bootstrap';
+import Row from 'react-bootstrap/lib/Row';
 
 import FormTypes from 'constants/FormTypes';
 import ReduxFormField from 'shared/form-fields/ReduxFormField';

--- a/app/shared/modals/reservation-info/ReservationOrderInfo.js
+++ b/app/shared/modals/reservation-info/ReservationOrderInfo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Well } from 'react-bootstrap';
+import Well from 'react-bootstrap/lib/Well';
 import { decamelizeKeys } from 'humps';
 
 import injectT from '../../../i18n/injectT';

--- a/app/shared/modals/reservation-payment/PaymentButton.js
+++ b/app/shared/modals/reservation-payment/PaymentButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
 
 import constants from '../../../constants/AppConstants';
 import injectT from '../../../i18n/injectT';

--- a/app/shared/modals/reservation-payment/PaymentModalContainer.js
+++ b/app/shared/modals/reservation-payment/PaymentModalContainer.js
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Button, Modal } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
+import Modal from 'react-bootstrap/lib/Modal';
 import classNames from 'classnames';
 
 import constants from '../../../constants/AppConstants';

--- a/app/shared/pagination/NumberedPageButtons.js
+++ b/app/shared/pagination/NumberedPageButtons.js
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Button } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/app/shared/quality-tools-form/QualityToolsForm.js
+++ b/app/shared/quality-tools-form/QualityToolsForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
 
 import injectT from '../../i18n/injectT';
 import StarInput from './StarInput';

--- a/app/shared/service-announcement/ServiceAnnouncement.js
+++ b/app/shared/service-announcement/ServiceAnnouncement.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Alert, Button } from 'react-bootstrap';
+import Alert from 'react-bootstrap/lib/Alert';
+import Button from 'react-bootstrap/lib/Button';
 import PropTypes from 'prop-types';
 
 import { injectT } from 'i18n';

--- a/app/shared/tooltip/TooltipOverlay.js
+++ b/app/shared/tooltip/TooltipOverlay.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { OverlayTrigger, Tooltip as BTTooltip } from 'react-bootstrap';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import BTTooltip from 'react-bootstrap/lib/Tooltip';
 import PropTypes from 'prop-types';
 
 function TooltipOverlay({

--- a/app/shared/top-navbar/mobile/MobileNavbar.js
+++ b/app/shared/top-navbar/mobile/MobileNavbar.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { Col, Row } from 'react-bootstrap';
+import Col from 'react-bootstrap/lib/Col';
+import Row from 'react-bootstrap/lib/Row';
 
 import FontChanger from 'shared/top-navbar/accessibility/TopNavbarFontContainer';
 import ContrastChanger from 'shared/top-navbar/accessibility/TopNavbarContrastContainer';

--- a/app/utils/languageUtils.js
+++ b/app/utils/languageUtils.js
@@ -1,4 +1,5 @@
-import { get, values } from 'lodash';
+import get from 'lodash/get';
+import values from 'lodash/values';
 
 import constants from 'constants/AppConstants';
 


### PR DESCRIPTION
# Better `react-bootstrap` and `lodash` imports

Changes:
- instead of importing whole `lodash` or `react-bootstrap` for some cases, import only what is needed from each package
