### PR TITLE
Moved phone number validation to its own file

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -14,7 +14,7 @@ import { Col, Row } from 'react-bootstrap';
 
 import FormTypes from 'constants/FormTypes';
 import constants from 'constants/AppConstants';
-import { isValidPhoneNumber, hasProducts, normalizeUniversalFieldOptions } from 'utils/reservationUtils';
+import { hasProducts, normalizeUniversalFieldOptions } from 'utils/reservationUtils';
 import ReduxFormField from 'shared/form-fields/ReduxFormField';
 import TermsField from 'shared/form-fields/TermsField';
 import { injectT } from 'i18n';
@@ -23,6 +23,7 @@ import WrappedText from 'shared/wrapped-text/WrappedText';
 import ReservationSubmitButton from './ReservationSubmitButton';
 import ReservationValidationErrors from './ReservationValidationErrors';
 import { FIELDS } from '../../../constants/ReservationConstants';
+import { isValidPhoneNumber } from '../../../utils/phoneValidationUtil';
 
 const validators = {
   reserverEmailAddress: (t, { reserverEmailAddress }) => {

--- a/app/shared/reservation-confirmation/ReservationForm.js
+++ b/app/shared/reservation-confirmation/ReservationForm.js
@@ -12,11 +12,12 @@ import isEmail from 'validator/lib/isEmail';
 
 import FormTypes from 'constants/FormTypes';
 import constants from 'constants/AppConstants';
-import { isValidPhoneNumber, normalizeUniversalFieldOptions } from 'utils/reservationUtils';
+import { normalizeUniversalFieldOptions } from 'utils/reservationUtils';
 import WrappedText from 'shared/wrapped-text';
 import ReduxFormField from 'shared/form-fields/ReduxFormField';
 import { injectT } from 'i18n';
 import TimeControls from './TimeControls';
+import { isValidPhoneNumber } from '../../utils/phoneValidationUtil';
 
 const validators = {
   reserverEmailAddress: (t, { reserverEmailAddress }) => {

--- a/app/utils/__tests__/phoneValidationUtil.spec.js
+++ b/app/utils/__tests__/phoneValidationUtil.spec.js
@@ -1,0 +1,43 @@
+import { isValidPhoneNumber } from '../phoneValidationUtil';
+
+describe('Utils: phoneValidationUtil', () => {
+  describe('isValidPhoneNumber', () => {
+    describe('when number contains non numbers excluding first + char', () => {
+      describe('returns false', () => {
+        test('when number is empty', () => {
+          expect(isValidPhoneNumber('')).toBe(false);
+        });
+
+        test('when number without + contains non number', () => {
+          expect(isValidPhoneNumber('123-123123')).toBe(false);
+        });
+
+        test('when number with + contains non number', () => {
+          expect(isValidPhoneNumber('+123-123123')).toBe(false);
+        });
+      });
+    });
+
+    describe('when number does not contains non numbers excluding first + char', () => {
+      describe('returns false', () => {
+        test('when number with + isnt valid', () => {
+          expect(isValidPhoneNumber('+12365645645645645645645')).toBe(false);
+        });
+
+        test('when number without + isnt valid', () => {
+          expect(isValidPhoneNumber('12')).toBe(false);
+        });
+      });
+      describe('returns true', () => {
+        test('when number with + is valid', () => {
+          expect(isValidPhoneNumber('+35840123123')).toBe(true);
+        });
+
+        test('when number without + is valid', () => {
+          expect(isValidPhoneNumber('04012312312')).toBe(true);
+        });
+      });
+    });
+  });
+});
+

--- a/app/utils/__tests__/reservationUtils.spec.js
+++ b/app/utils/__tests__/reservationUtils.spec.js
@@ -12,7 +12,6 @@ import {
   getMissingValues,
   getNextAvailableTime,
   getNextReservation,
-  isValidPhoneNumber,
   createOrderLines,
   hasOrder,
   hasPayment,
@@ -330,45 +329,6 @@ describe('Utils: reservationUtils', () => {
 
     test('returns the next reservation from a list of reservations', () => {
       expect(getNextReservation(unorderedReservations)).toEqual(nextReservation);
-    });
-  });
-
-  describe('isValidPhoneNumber', () => {
-    describe('when number contains non numbers excluding first + char', () => {
-      describe('returns false', () => {
-        test('when number is empty', () => {
-          expect(isValidPhoneNumber('')).toBe(false);
-        });
-
-        test('when number without + contains non number', () => {
-          expect(isValidPhoneNumber('123-123123')).toBe(false);
-        });
-
-        test('when number with + contains non number', () => {
-          expect(isValidPhoneNumber('+123-123123')).toBe(false);
-        });
-      });
-    });
-
-    describe('when number does not contains non numbers excluding first + char', () => {
-      describe('returns false', () => {
-        test('when number with + isnt valid', () => {
-          expect(isValidPhoneNumber('+12365645645645645645645')).toBe(false);
-        });
-
-        test('when number without + isnt valid', () => {
-          expect(isValidPhoneNumber('12')).toBe(false);
-        });
-      });
-      describe('returns true', () => {
-        test('when number with + is valid', () => {
-          expect(isValidPhoneNumber('+35840123123')).toBe(true);
-        });
-
-        test('when number without + is valid', () => {
-          expect(isValidPhoneNumber('04012312312')).toBe(true);
-        });
-      });
     });
   });
 

--- a/app/utils/phoneValidationUtil.js
+++ b/app/utils/phoneValidationUtil.js
@@ -1,0 +1,28 @@
+import { PhoneNumberUtil } from 'google-libphonenumber';
+
+export function isValidPhoneNumber(number) {
+  // only allow numbers and + if its the first char
+  const regex = /^([+]\d*|\d*)$/;
+  if (regex.test(number) === false) {
+    return false;
+  }
+
+  const phoneUtil = PhoneNumberUtil.getInstance();
+  // if number starts with +, try to parse with any country code
+  if (number && number[0] === '+') {
+    try {
+      const parsedNumber = phoneUtil.parse(number, '');
+      return phoneUtil.isValidNumber(parsedNumber);
+    } catch (error) {
+      return false;
+    }
+  } else {
+    // if number doesnt start with +, assume country code is FI
+    try {
+      const parsedNumber = phoneUtil.parseAndKeepRawInput(number, 'FI');
+      return phoneUtil.isValidNumber(parsedNumber);
+    } catch (error) {
+      return false;
+    }
+  }
+}

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -8,7 +8,6 @@ import sortBy from 'lodash/sortBy';
 import tail from 'lodash/tail';
 import get from 'lodash/get';
 import moment from 'moment';
-import { PhoneNumberUtil } from 'google-libphonenumber';
 
 import constants from 'constants/AppConstants';
 import { FIELDS } from 'constants/ReservationConstants';
@@ -89,33 +88,6 @@ function getEditReservationUrl(reservation) {
   const endStr = moment(end).format('HH:mm');
 
   return `/reservation?begin=${beginStr}&date=${date}&end=${endStr}&id=${id || ''}&resource=${resource}`;
-}
-
-function isValidPhoneNumber(number) {
-  // only allow numbers and + if its the first char
-  const regex = /^([+]\d*|\d*)$/;
-  if (regex.test(number) === false) {
-    return false;
-  }
-
-  const phoneUtil = PhoneNumberUtil.getInstance();
-  // if number starts with +, try to parse with any country code
-  if (number && number[0] === '+') {
-    try {
-      const parsedNumber = phoneUtil.parse(number, '');
-      return phoneUtil.isValidNumber(parsedNumber);
-    } catch (error) {
-      return false;
-    }
-  } else {
-    // if number doesnt start with +, assume country code is FI
-    try {
-      const parsedNumber = phoneUtil.parseAndKeepRawInput(number, 'FI');
-      return phoneUtil.isValidNumber(parsedNumber);
-    } catch (error) {
-      return false;
-    }
-  }
 }
 
 /**
@@ -447,7 +419,6 @@ export {
   getMissingValues,
   getNextAvailableTime,
   getNextReservation,
-  isValidPhoneNumber,
   changeProductQuantity,
   getExtraProducts,
   getMandatoryProducts,


### PR DESCRIPTION
# Phone number validation moved to its own file

Moved phone number validation to its own file/module to split code imports better. Phone number validation uses `google-libphonenumber` imported package which is very large.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### phone number validation code split
 1. app/pages/reservation/reservation-information/ReservationInformationForm.js
 2. app/shared/reservation-confirmation/ReservationForm.js
     * changed phone validation import location
   
 3. app/utils/phoneValidationUtil.js
     * a new file for phone validation function
    
 4. app/utils/reservationUtils.js
     * removed phone validation function from general reservation utils