### PR TITLE
Fixed heading level skip in not found page

### DIFF
--- a/app/pages/not-found/NotFoundPage.js
+++ b/app/pages/not-found/NotFoundPage.js
@@ -15,7 +15,7 @@ function NotFoundPage({ t }) {
         <h1>{t('NotFoundPage.title')}</h1>
         <p className="lead">{t('NotFoundPage.lead')}</p>
         <Well>
-          <h5>{t('NotFoundPage.helpHeader')}</h5>
+          <p className="h4">{t('NotFoundPage.helpHeader')}</p>
           <ul>
             <li>
               <FormattedMessage

--- a/app/pages/not-found/NotFoundPage.spec.js
+++ b/app/pages/not-found/NotFoundPage.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Well from 'react-bootstrap/lib/Well';
 
 import PageWrapper from 'pages/PageWrapper';
 import { shallowWithIntl } from 'utils/testUtils';
@@ -18,6 +19,18 @@ describe('pages/not-found/NotFoundPage', () => {
   test('renders correct title inside h1 tags', () => {
     const h1 = getWrapper().find('h1');
     expect(h1.props().children).toBe('NotFoundPage.title');
+  });
+
+  test('renders a Well component', () => {
+    const well = getWrapper().find(Well);
+    expect(well.length).toBe(1);
+  });
+
+  test('renders correct help header text within Well', () => {
+    const p = getWrapper().find(Well).find('p');
+    expect(p.length).toBe(1);
+    expect(p.prop('className')).toBe('h4');
+    expect(p.props().children).toBe('NotFoundPage.helpHeader');
   });
 
   test('renders a list and list elements for displaying help to user', () => {


### PR DESCRIPTION
# Fixed heading level skip in not found page

Changed html heading used for styling purposes to `p` element with similar css styles

-----------------------------------------------------------------------------------------------
### Breakdown:

#### fix to improper use of heading
 1. app/pages/not-found/NotFoundPage.js
     * switched h5 to p with styling that better fit the page