### PR TITLE
Changed Service Map link texts and URLs

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -427,7 +427,7 @@
   "ResourceIcons.free": "Free of charge",
   "ResourceInfo.additionalInfoTitle": "Additional information about the premises",
   "ResourceInfo.equipmentHeader": "Equipment available at the premises",
-  "ResourceInfo.serviceMapLink": "Search route on Service Map",
+  "ResourceInfo.serviceMapLink": "View location on Service Map",
   "ResourceInfo.webSiteLink": "Premise website",
   "ResourceInfo.loginMessage": "You must <a href=”/login”>log in</a> to reserve these premises.",
   "ResourceInfo.reservationTitle": "Reservation information",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -427,7 +427,7 @@
   "ResourceIcons.free": "Maksuton",
   "ResourceInfo.additionalInfoTitle": "Tilan lisätiedot",
   "ResourceInfo.equipmentHeader": "Tilan varusteet",
-  "ResourceInfo.serviceMapLink": "Katso reitti Palvelukartasta",
+  "ResourceInfo.serviceMapLink": "Katso sijanti Palvelukartasta",
   "ResourceInfo.webSiteLink": "Toimipisteen Nettisivut",
   "ResourceInfo.loginMessage": "Sinun täytyy <a href=\"/login\">kirjautua sisään</a>, jotta voit tehdä varauksen tähän tilaan.",
   "ResourceInfo.reservationTitle": "Varauksen tiedot",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -430,7 +430,7 @@
   "ResourceInfo.additionalInfoTitle": "Ytterligare information",
   "ResourceInfo.equipmentHeader": "Utrustning",
   "ResourceInfo.webSiteLink": "Lokalets webbsida",
-  "ResourceInfo.serviceMapLink": "Reseplanering i Servicekartan",
+  "ResourceInfo.serviceMapLink": "Se plats på Servicekartan",
   "ResourceInfo.loginMessage": "För att kunna boka detta utrymme måste du <a href=”/login”>logga in</a>.",
   "ResourceInfo.reservationTitle": "Bokningsinformation",
   "ResourceInfo.reserveTitle": "Boka utrymme",

--- a/app/utils/__tests__/unitUtils.spec.js
+++ b/app/utils/__tests__/unitUtils.spec.js
@@ -7,7 +7,7 @@ describe('Utils: unitUtils', () => {
     test('returns correct url when unit has mapServiceId defined and current language is sv', () => {
       const unit = { mapServiceId: '123' };
       const currentLanguage = 'sv';
-      const expected = 'https://servicekarta.turku.fi/unit/123#!route-details';
+      const expected = 'https://palvelukartta.turku.fi/sv/unit/123';
 
       expect(getServiceMapUrl(unit, currentLanguage)).toBe(expected);
     });
@@ -15,7 +15,7 @@ describe('Utils: unitUtils', () => {
     test('returns correct url when unit has mapServiceId defined and current language is fi', () => {
       const unit = { mapServiceId: '123' };
       const currentLanguage = 'fi';
-      const expected = 'https://palvelukartta.turku.fi/unit/123#!route-details';
+      const expected = 'https://palvelukartta.turku.fi/fi/unit/123';
 
       expect(getServiceMapUrl(unit, currentLanguage)).toBe(expected);
     });
@@ -23,15 +23,15 @@ describe('Utils: unitUtils', () => {
     test('returns correct url when unit has mapServiceId defined and current language is en', () => {
       const unit = { mapServiceId: '123' };
       const currentLanguage = 'en';
-      const expected = 'https://servicemap.turku.fi/unit/123#!route-details';
+      const expected = 'https://palvelukartta.turku.fi/en/unit/123';
 
       expect(getServiceMapUrl(unit, currentLanguage)).toBe(expected);
     });
 
-    test('returns finnish url when unit has mapServiceId defined but language code is not one of the defined ones', () => {
+    test('returns base url when unit has mapServiceId defined but language code is not one of the defined ones', () => {
       const unit = { mapServiceId: '123' };
       const currentLanguage = 'test';
-      const expected = 'https://palvelukartta.turku.fi/unit/123#!route-details';
+      const expected = 'https://palvelukartta.turku.fi/unit/123';
 
       expect(getServiceMapUrl(unit, currentLanguage)).toBe(expected);
     });

--- a/app/utils/unitUtils.js
+++ b/app/utils/unitUtils.js
@@ -14,13 +14,13 @@ function getServiceMapUrl(unit, currentLanguage) {
 
   switch (currentLanguage) {
     case 'sv':
-      return `https://servicekarta.turku.fi/unit/${unit.mapServiceId}#!route-details`;
+      return `https://palvelukartta.turku.fi/sv/unit/${unit.mapServiceId}`;
     case 'fi':
-      return `https://palvelukartta.turku.fi/unit/${unit.mapServiceId}#!route-details`;
+      return `https://palvelukartta.turku.fi/fi/unit/${unit.mapServiceId}`;
     case 'en':
-      return `https://servicemap.turku.fi/unit/${unit.mapServiceId}#!route-details`;
+      return `https://palvelukartta.turku.fi/en/unit/${unit.mapServiceId}`;
     default:
-      return `https://palvelukartta.turku.fi/unit/${unit.mapServiceId}#!route-details`;
+      return `https://palvelukartta.turku.fi/unit/${unit.mapServiceId}`;
   }
 }
 


### PR DESCRIPTION
# Changed Service Map link texts and URLs

Changes:
- removed routing param from urls because Service Map no longer supports it
- changed Service Map link texts to reflect its new intent to only show location instead of routing
- changed urls for different languages because url language routing has changed in Service Map

[Related Trello card](https://trello.com/c/YPmF8WzQ)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Service Map links
 1. app/utils/unitUtils.js
     * removed routing param and changed how different languages are linked to Service Map
