### PR TITLE
Fixed reservation error list not showing issue

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -1,5 +1,6 @@
 
 import includes from 'lodash/includes';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -151,7 +152,7 @@ class UnconnectedReservationInformationForm extends Component {
     const { showFormErrorList } = this.state;
     const { formValues } = this.props;
     if (showFormErrorList) {
-      if (formValues !== prevProps.formValues) {
+      if (!isEqual(formValues, prevProps.formValues)) {
         this.setState({ showFormErrorList: false, formErrors: [] });
       }
     }


### PR DESCRIPTION
# Fixed reservation error list not showing issue

Reservation page field error list did not always show error list correctly. Changed reservation field value comparisons to use lodash isEqual to fix the issue.

[Related Trello card](https://trello.com/c/266anBh6)