### PR TITLE
Added env `HTTP_CACHE_MAX_AGE` setting

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -6,6 +6,8 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 const defaultPort = isProduction ? 8080 : 3000;
 const port = process.env.PORT || defaultPort;
+// max age can be given in many units like seconds(s), minutes(m), hours(h) and days(d)
+const httpCacheMaxAge = process.env.HTTP_CACHE_MAX_AGE || '30d';
 
 function getAssetHash(filePath) {
   if (!isProduction) return '';
@@ -33,4 +35,5 @@ module.exports = {
   matomoSiteId: process.env.MATOMO_SITE_ID,
   port,
   webpackStylesExtensions: ['css', 'scss'],
+  httpCacheMaxAge,
 };

--- a/server/main.js
+++ b/server/main.js
@@ -24,7 +24,7 @@ if (serverConfig.isProduction) {
   app.use(compression());
 
   // Serve the static assets. We can cache them as they include hashes.
-  app.use('/_assets', express.static(path.resolve(__dirname, '../dist'), { maxAge: '200d' }));
+  app.use('/_assets', express.static(path.resolve(__dirname, '../dist'), { maxAge: serverConfig.httpCacheMaxAge }));
 } else {
   const webpackConfig = require('../config/webpack.development');
   const compiler = webpack(webpackConfig);


### PR DESCRIPTION
# HTTP cache max age ENV setting

This env setting controls production http cache max age. Default value is '30d' when setting is not given. Max age can be given in many units like seconds(s), minutes(m), hours(h) and days(d).

[Related Trello card](https://trello.com/c/9X062rpm)

-----------------------------------------------------------------------------------------------
## Breakdown:

### http cache max age
 1. server/config.js
     * get env `HTTP_CACHE_MAX_AGE` and set it to a variable or use default value of ´30d´
   
 2. server/main.js
     * set http cache max age value to be defined max age value