### PR TITLE
Removed google site verification meta tag

### DIFF
--- a/server/Html.js
+++ b/server/Html.js
@@ -83,7 +83,6 @@ class Html extends Component {
           <meta content="Varaamo, Turku, Kirjasto, Pääkirjasto, Yliopisto, Palvelu, Pelitila, Soittohuone, Työpiste, 3D-tulostin, Stoori, Varauspalvelu, Kokoustila, Tulostus, Mikrofilmit, Musiikki, Askartelut" name="keywords" />
           <meta content="Turun kaupungin Varaamo-palvelusta voit varata tiloja, laitteita ja palveluita, kun haluat pitää kokouksen, pelata pelejä, harrastaa tai tavata asiantuntijan." name="description" />
           <meta content="Digipoint" name="author" />
-          <meta content="x4GUwZEJru1x6OpgxdEMMfLatFyGx5lmxlbD0AMqtbw" name="google-site-verification" />
           <meta content={ogImage} property="og:image" />
           <meta content="image/jpeg" property="og:image:type" />
           <meta content="1200" property="og:image:width" />


### PR DESCRIPTION
# Removed google site verification meta tag

The meta tag is not necessary and not in use currently.

[Related Trello card](https://trello.com/c/oFaUXuRx)