### PR TITLE
Fixed a possible overflow in manage reservations

### DIFF
--- a/app/pages/manage-reservations/_manage-reservations-page.scss
+++ b/app/pages/manage-reservations/_manage-reservations-page.scss
@@ -37,5 +37,6 @@
 
   &__list {
     margin-top: 20px;
+    margin-bottom: 32px;
   }
 }


### PR DESCRIPTION
# Fixed a possible overflow in manage reservations

When only one reservation is listed in manage reservations page, the drop down actions for the reservation could be hidden be the footer. This fix increases reservation list margin so that all the drop down actions fit in view.

[Related Trello card](https://trello.com/c/vQyatsCK)