### PR TITLE
Added asterisk meaning to reservation info page

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -102,6 +102,7 @@
   "common.save": "Save",
   "common.saving": "Saving...",
   "common.select": "Select",
+  "common.starFieldsAreRequired": "The fields marked with an asterisk (*) are mandatory.",
   "common.taxesTotal": "Total taxes",
   "common.taxlessTotal": "Tax-free total",
   "common.total": "total",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -102,6 +102,7 @@
   "common.save": "Tallenna",
   "common.saving": "Tallennetaan...",
   "common.select": "Valitse",
+  "common.starFieldsAreRequired": "Tähdellä (*) merkityt tiedot ovat pakollisia.",
   "common.taxesTotal": "Verot yhteensä",
   "common.taxlessTotal": "Veroton yhteensä",
   "common.total": "yhteensä",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -102,6 +102,7 @@
   "common.save": "Spara",
   "common.saving": "Sparas...",
   "common.select": "Välj",
+  "common.starFieldsAreRequired": "Uppgifterna markerade med en asterisk (*) är obligatoriska.",
   "common.taxesTotal": "Totala skatter",
   "common.taxlessTotal": "Skattefritt totalt",
   "common.total": "totalt",

--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -186,6 +186,9 @@ class ReservationInformation extends Component {
             <p>{t('ConfirmReservationModal.formInfo')}</p>
           </React.Fragment>
         )}
+        {!resource.needManualConfirmation && (
+          <p>{t('common.starFieldsAreRequired')}</p>
+        )}
       </div>
     );
   }

--- a/app/pages/reservation/reservation-information/ReservationInformation.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.spec.js
@@ -65,6 +65,7 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
     const infoTexts = getWrapper({ resource }).find('.app-ReservationInformation__info-texts');
     expect(infoTexts).toHaveLength(1);
     expect(infoTexts.text()).toContain('common.contactPurposeHelp');
+    expect(infoTexts.text()).toContain('common.starFieldsAreRequired');
   });
 
   test('renders an ReservationInformationForm element', () => {


### PR DESCRIPTION
# Added asterisk meaning to reservation info page

Added a new help text in the reservation page above the form when making non manually confirmed reservations. The help text explains that fields marked with asterisk are required.

[Related Trello card](https://trello.com/c/5yHzbbdH)