### PR TITLE
Added created at to reservation info for staff

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -89,6 +89,7 @@
   "common.proceedToPayment": "Proceed to payment",
   "common.proceedingToPayment": "Proceeding to payment...",
   "common.requested": "Waiting for processing",
+  "common.reservationCreatedAt": "Reservation created at",
   "common.reservationTimeLabel": "Time and date of the reservation",
   "common.reserverAddressLabel": "Address",
   "common.reserverEmailAddressLabel": "E-mail",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -89,6 +89,7 @@
   "common.proceedToPayment": "Siirry maksamaan",
   "common.proceedingToPayment": "Siirrytään maksamaan...",
   "common.requested": "Odottaa käsittelyä",
+  "common.reservationCreatedAt": "Varauksen luontiaika",
   "common.reservationTimeLabel": "Varauksen ajankohta",
   "common.reserverAddressLabel": "Osoite",
   "common.reserverEmailAddressLabel": "Sähköposti",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -89,6 +89,7 @@
   "common.proceedToPayment": "Fortsätt till betalning",
   "common.proceedingToPayment": "Fortsätter till betalning...",
   "common.requested": "Behandlas",
+  "common.reservationCreatedAt": "Bokning skapande tid",
   "common.reservationTimeLabel": "Tidpunkt för bokning",
   "common.reserverAddressLabel": "Adress",
   "common.reserverEmailAddressLabel": "E-post",

--- a/app/shared/modals/reservation-info/ReservationEditForm.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.js
@@ -21,6 +21,7 @@ import { injectT } from 'i18n';
 import ReservationOrderInfo from './ReservationOrderInfo';
 import { getReservationCustomerGroupName } from 'utils/reservationUtils';
 import constants from '../../../constants/AppConstants';
+import { formatDateTime } from '../../../utils/timeUtils';
 
 class UnconnectedReservationEditForm extends Component {
   constructor(props) {
@@ -219,6 +220,9 @@ class UnconnectedReservationEditForm extends Component {
             {this.renderInfoRow(t('ReservationType.label'),
               reservation.type === constants.RESERVATION_TYPE.BLOCKED_VALUE
                 ? t('ReservationType.blocked') : t('ReservationType.normal'))}
+            {reservation.createdAt && (
+              this.renderInfoRow(t('common.reservationCreatedAt'), formatDateTime(reservation.createdAt, 'LLLL'))
+            )}
           </Well>
         )}
         {this.renderEditableInfoRow('eventSubject', 'text')}

--- a/app/shared/modals/reservation-info/ReservationEditForm.spec.js
+++ b/app/shared/modals/reservation-info/ReservationEditForm.spec.js
@@ -11,6 +11,7 @@ import { shallowWithIntl } from 'utils/testUtils';
 import { UnconnectedReservationEditForm as ReservationEditForm } from './ReservationEditForm';
 import ReservationOrderInfo from './ReservationOrderInfo';
 import constants from '../../../constants/AppConstants';
+import { formatDateTime } from '../../../utils/timeUtils';
 
 describe('shared/modals/reservation-info/ReservationEditForm', () => {
   const resource = Resource.build({ universalField: [UniversalField.build()] });
@@ -220,6 +221,32 @@ describe('shared/modals/reservation-info/ReservationEditForm', () => {
           test('does not render reservation type', () => {
             expect(getData({ reservation: reservationA, isStaff })).not.toContain('ReservationType.blocked');
             expect(getData({ reservation: reservationB, isStaff })).not.toContain('ReservationType.normal');
+          });
+        });
+      });
+
+      describe('reservation created at', () => {
+        const reservationA = Reservation.build({ createdAt: '2023-11-20T15:00:00' });
+        const reservationB = Reservation.build();
+
+        describe('when user is staff', () => {
+          const isStaff = true;
+
+          test('is not rendered when created at is not included in reservation', () => {
+            expect(getData({ reservation: reservationB, isStaff })).not.toContain('common.reservationCreatedAt');
+          });
+          test('is rendered when created at is included in reservation', () => {
+            expect(getData({ reservation: reservationA, isStaff })).toContain('common.reservationCreatedAt');
+            expect(getData({ reservation: reservationA, isStaff })).toContain(formatDateTime(reservationA.createdAt, 'LLLL'));
+          });
+        });
+
+        describe('when user is not staff', () => {
+          const isStaff = false;
+
+          test('is not rendered', () => {
+            expect(getData({ reservation: reservationB, isStaff })).not.toContain('common.reservationCreatedAt');
+            expect(getData({ reservation: reservationA, isStaff })).not.toContain('common.reservationCreatedAt');
           });
         });
       });

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -25,7 +25,8 @@ import {
   prettifyHours,
   periodToMinute,
   getEndTimeSlotWithMinPeriod,
-  formatTime
+  formatTime,
+  formatDateTime,
 } from 'utils/timeUtils';
 
 const moment = extendMoment(Moment);
@@ -835,6 +836,17 @@ describe('Utils: timeUtils', () => {
       ['8:00', 'H:mm', 'HH', '08'],
     ])('returns correctly formatted time string with given params', (time, timeFormat, targetTimeFormat, expected) => {
       expect(formatTime(time, timeFormat, targetTimeFormat)).toBe(expected);
+    });
+  });
+
+  describe('formatDatetime', () => {
+    test.each([
+      ['2023-11-01T15:00:00Z', 'YYYY-MM-DD HH:mm', '2023-11-01 17:00'],
+      ['2023-11-01T15:00:00Z', 'YYYY.MM.DD', '2023.11.01'],
+      ['2023-11-01T15:00:00Z', 'L', '01.11.2023'],
+      ['2023-11-01T34:00:00', 'L', '2023-11-01T34:00:00'],
+    ])('returns correctly formatted datetime string with given params', (datetime, targetFormat, expected) => {
+      expect(formatDateTime(datetime, targetFormat)).toBe(expected);
     });
   });
 });

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -327,6 +327,18 @@ function formatTime(time, timeFormat, targetTimeFormat) {
   return moment(time, timeFormat).format(targetTimeFormat);
 }
 
+/**
+ * Parses and formats given datetime into desired target format.
+ * @param {string} datetime e.g. "2023-11-24T14:00:00"
+ * @param {string} targetFormat desired datetime format parsable by Moment for output
+ * e.g. "LLLL"
+ * @returns {string} formatted datetime string or given datetime when datetime is not valid
+ */
+function formatDateTime(datetime, targetFormat) {
+  const datetimeMoment = moment(datetime);
+  return datetimeMoment.isValid() ? datetimeMoment.format(targetFormat) : datetime;
+}
+
 export {
   addToDate,
   calculateDuration,
@@ -348,4 +360,5 @@ export {
   getEndTimeSlotWithMinPeriod,
   getTimeDiff,
   formatTime,
+  formatDateTime,
 };


### PR DESCRIPTION
# Added created at to reservation info for staff

Staff members can now see reservation creation time in reservation info modal if the creation time is included in reservation data.

[Related Trello card](https://trello.com/c/2iOjouvF)