### PR TITLE
Included order number in reservation order info

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -75,6 +75,7 @@
   "common.ok": "OK",
   "common.optionsAllLabel": "All",
   "common.orderDetailsLabel": "Order details",
+  "common.orderNumber": "Order number",
   "common.payerInformationLabel": "Payer information",
   "common.paymentAborted": "Payment aborted",
   "common.paymentMethod": "Payment method",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -75,6 +75,7 @@
   "common.ok": "Valmis",
   "common.optionsAllLabel": "Kaikki",
   "common.orderDetailsLabel": "Tilaustiedot",
+  "common.orderNumber": "Tilausnumero",
   "common.payerInformationLabel": "Maksajan tiedot",
   "common.paymentAborted": "Maksu keskeytyi",
   "common.paymentMethod": "Maksutapa",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -75,6 +75,7 @@
   "common.ok": "OK",
   "common.optionsAllLabel": "Alla",
   "common.orderDetailsLabel": "Orderdetaljer",
+  "common.orderNumber": "Ordernummer",
   "common.payerInformationLabel": "Betalarens information",
   "common.paymentAborted": "Betalningen avbröts",
   "common.paymentMethod": "Betalningsmetod",

--- a/app/shared/modals/reservation-info/ReservationOrderInfo.js
+++ b/app/shared/modals/reservation-info/ReservationOrderInfo.js
@@ -51,6 +51,7 @@ function ReservationOrderInfo({
       {renderInfoRow(t('common.taxesTotal'), `${nonZeroTaxTotal} €`)}
       {renderInfoRow(t('common.priceTotalLabel'), `${order.price} €`)}
       {orderPaymentMethod && (renderInfoRow(t('common.paymentMethod'), orderPaymentMethod))}
+      {renderInfoRow(t('common.orderNumber'), order.id)}
     </Well>
   );
 }

--- a/app/shared/modals/reservation-info/ReservationOrderInfo.spec.js
+++ b/app/shared/modals/reservation-info/ReservationOrderInfo.spec.js
@@ -18,6 +18,7 @@ describe('shared/modals/reservation-info/ReservationOrderInfo', () => {
       orderLines: [decamelizeKeys(OrderLine.build({ product: Product.build(), quantity: 1 }))],
       price: '5.00',
       paymentMethod: constants.PAYMENT_METHODS.ONLINE,
+      id: 'test-id',
     },
     renderHeading: () => {},
     renderInfoRow: () => {},
@@ -100,6 +101,11 @@ describe('shared/modals/reservation-info/ReservationOrderInfo', () => {
           expect(renderInfoRow).not.toHaveBeenCalledWith('common.paymentMethod', 'common.paymentMethod.online');
           expect(renderInfoRow).not.toHaveBeenCalledWith('common.paymentMethod', 'common.paymentMethod.cash');
         });
+      });
+
+      test('for order id', () => {
+        getWrapper({ renderInfoRow });
+        expect(renderInfoRow).toHaveBeenCalledWith('common.orderNumber', defaultProps.order.id);
       });
     });
   });


### PR DESCRIPTION
# Included order number in reservation order info

Staff and clients are now able to see their order's order number in order details section of reservation info modal.

[Related Trello card](https://trello.com/c/3ec36FL8)
