### PR TITLE
Fixed low contrast 'accept' buttons in reservation info modals

### DIFF
--- a/app/shared/modals/reservation-info/_reservation-info-modal.scss
+++ b/app/shared/modals/reservation-info/_reservation-info-modal.scss
@@ -105,6 +105,11 @@
       border-width: 1px;
     }
   }
+
+  .btn-success {
+    color: #008540;
+    border-color: #008540;
+  }
 }
 
 .high-contrast {


### PR DESCRIPTION
# Fixed low contrast 'accept' buttons in reservation info modals

Default 'success' green color has low contrast ratio in reservation info modals. This change makes the contrast better for buttons like 'Confirm reservation' and 'Approve cash payment'.
