### PR TITLE
Added missing language prop into footer content test

### DIFF
--- a/app/shared/footer/FooterContent.spec.js
+++ b/app/shared/footer/FooterContent.spec.js
@@ -8,8 +8,12 @@ import { shallowWithIntl } from 'utils/testUtils';
 import FooterContent from './FooterContent';
 
 describe('shared/footer/FooterContent', () => {
+  const defaultProps = {
+    currentLang: 'fi',
+  };
+
   function getWrapper(props) {
-    return shallowWithIntl(<FooterContent {...props} />);
+    return shallowWithIntl(<FooterContent {...defaultProps} {...props} />);
   }
 
   describe('When there is no customization in use', () => {


### PR DESCRIPTION
Footer content unit test did not pass in required `currentLang` prop which caused a console warning when running unit tests. This addition fixes the issue.