### PR TITLE
Added focus outline to my premises page resource links

### DIFF
--- a/app/shared/availability-view/_availability-view.scss
+++ b/app/shared/availability-view/_availability-view.scss
@@ -192,7 +192,6 @@
     }
   }
 
-  // Fixes to alignment, sizing, borders and text overflow
   .resource-info {
     display: flex;
     align-items: flex-start;
@@ -223,9 +222,12 @@
       max-width: 100%;
       padding-bottom: 3px;
 
+      &:focus-within {
+        outline: 2px solid currentColor;
+      }
+
       a {
         color: $text-color;
-
         font-weight: $headings-font-weight;
       }
     }


### PR DESCRIPTION
# Added focus outline to my premises page resource links

My premises page resource links did not have clear enough highlighting for keyboard navigation. This addition fixes the issue.

[Related Trello card](https://trello.com/c/LeWaqARN)