### PR TITLE
Changed resource time slot isAdmin check

### DIFF
--- a/app/pages/resource/reservation-calendar/ReservationCalendarContainer.js
+++ b/app/pages/resource/reservation-calendar/ReservationCalendarContainer.js
@@ -28,7 +28,7 @@ import ReservationConfirmation from 'shared/reservation-confirmation';
 import recurringReservations from 'state/recurringReservations';
 import { injectT } from 'i18n';
 import { getEditReservationUrl } from 'utils/reservationUtils';
-import { hasMaxReservations, reservingIsRestricted } from 'utils/resourceUtils';
+import { hasMaxReservations, reservingIsRestricted, isStaffForResource } from 'utils/resourceUtils';
 import reservationCalendarSelector from './reservationCalendarSelector';
 import ReservingRestrictedText from './ReservingRestrictedText';
 import TimeSlots from './time-slots';
@@ -155,6 +155,8 @@ export class UnconnectedReservationCalendarContainer extends Component {
     const isOpen = Boolean(timeSlots.length);
     const showTimeSlots = isOpen && !reservingIsRestricted(resource, date);
     const selectedDateSlots = this.getSelectedDateSlots(timeSlots, selected);
+    const isResourceStaff = (isAdmin && resource) ? isStaffForResource(resource) : false;
+
     return (
       <div className="reservation-calendar">
         <h3 className="visually-hidden reservation-calendar__header">{t('ReservationCalendar.header')}</h3>
@@ -162,7 +164,7 @@ export class UnconnectedReservationCalendarContainer extends Component {
           <TimeSlots
             addNotification={debounce(actions.addNotification, 100)}
             // TODO: Im a h@ck, remove me
-            isAdmin={isAdmin}
+            isAdmin={isResourceStaff}
             isEditing={isEditing}
             isFetching={isFetchingResource}
             isLoggedIn={isLoggedIn || resource.authentication === 'unauthenticated'} // count as logged in if no auth needed

--- a/app/pages/resource/reservation-calendar/ReservationCalendarContainer.spec.js
+++ b/app/pages/resource/reservation-calendar/ReservationCalendarContainer.spec.js
@@ -13,6 +13,7 @@ import { shallowWithIntl } from 'utils/testUtils';
 import { UnconnectedReservationCalendarContainer as ReservationCalendarContainer } from './ReservationCalendarContainer';
 import ReservingRestrictedText from './ReservingRestrictedText';
 import TimeSlots from './time-slots';
+import { isStaffForResource } from '../../../utils/resourceUtils';
 
 describe('pages/resource/reservation-calendar/ReservationCalendarContainer', () => {
   const actions = {
@@ -91,7 +92,15 @@ describe('pages/resource/reservation-calendar/ReservationCalendarContainer', () 
     });
 
     test(`${renderTimeSlots ? 'renders' : 'does not render'} TimeSlots`, () => {
-      expect(wrapper.find(TimeSlots).length === 1).toBe(renderTimeSlots);
+      const timeslots = wrapper.find(TimeSlots);
+      expect(timeslots.length === 1).toBe(renderTimeSlots);
+      if (renderTimeSlots) {
+        const isResourceStaff = (defaultProps.isAdmin && defaultProps.resource)
+          ? isStaffForResource(resource) : false;
+        expect(timeslots.prop('isAdmin')).toBe(isResourceStaff);
+        expect(timeslots.prop('isEditing')).toBe(defaultProps.isEditing);
+        expect(timeslots.prop('resource')).toBe(defaultProps.resource);
+      }
     });
 
     test(`${renderClosedText ? 'renders' : 'does not render'} closed text`, () => {


### PR DESCRIPTION
# Changed resource time slot isAdmin check

Before only user's general staff perm was used in `isAdmin` check. Now `isAdmin` is checked against unit permissions (admin, manager, viewer).

[Related Trello card](https://trello.com/c/hdtjIXV5)