### PR TITLE
Added min & max period info for my premises ext resource reservation creation

### DIFF
--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/ReservationSlot.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/ReservationSlot.js
@@ -22,6 +22,9 @@ export class UninjectedReservationSlot extends React.Component {
       hover: PropTypes.bool,
       resourceId: PropTypes.string.isRequired,
     }),
+    maxPeriod: PropTypes.string,
+    minPeriod: PropTypes.string,
+    hasStaffRights: PropTypes.bool,
   };
 
   constructor(props) {
@@ -107,6 +110,8 @@ export class UninjectedReservationSlot extends React.Component {
         <ReservationPopover
           begin={this.props.selection.begin}
           end={this.props.selection.end}
+          maxPeriod={this.props.hasStaffRights ? null : this.props.maxPeriod}
+          minPeriod={this.props.hasStaffRights ? null : this.props.minPeriod}
           onCancel={this.props.onSelectionCancel}
         >
           {slot}

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/ReservationSlot.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/ReservationSlot.spec.js
@@ -101,6 +101,24 @@ describe('shared/availability-view/ReservationSlot', () => {
       });
       expect(popover).toHaveLength(1);
     });
+
+    test('renders with min and max prop when hasStaffRights is true', () => {
+      const popover = getPopover({
+        begin: '2016-01-01T10:00:00Z',
+        end: '2016-01-01T10:30:00Z',
+        selection: {
+          begin: '2016-01-01T10:00:00Z',
+          end: '2016-01-01T12:00:00Z',
+          resourceId: '1',
+        },
+        hasStaffRights: false,
+        minPeriod: '00:30:00',
+        maxPeriod: '01:00:00',
+      });
+      expect(popover).toHaveLength(1);
+      expect(popover.prop('minPeriod')).toBe('00:30:00');
+      expect(popover.prop('maxPeriod')).toBe('01:00:00');
+    });
   });
 
   describe('selection', () => {

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.js
@@ -15,7 +15,7 @@ function getTimeSlotWidth({ startTime, endTime } = {}) {
 }
 
 function getTimelineItems(date, reservations, resourceId, timeRestrictions, hasStaffRights) {
-  const { cooldown } = timeRestrictions;
+  const { cooldown, minPeriod, maxPeriod } = timeRestrictions;
   // skip getting cooldowns if user has perms
   const cooldownRanges = hasStaffRights ? [] : getCooldownRanges(reservations, cooldown);
   const items = [];
@@ -51,7 +51,9 @@ function getTimelineItems(date, reservations, resourceId, timeRestrictions, hasS
           // addSelectionData to make some assumptions.
           isSelectable: false,
           isWithinCooldown,
-          hasStaffRights
+          hasStaffRights,
+          minPeriod,
+          maxPeriod
         },
       });
       timePointer.add(slotSize, 'minutes');

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js
@@ -245,6 +245,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -257,6 +259,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -269,6 +273,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -281,6 +287,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         { key: '4', type: 'reservation', data: reservations[0] },
@@ -294,6 +302,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -306,6 +316,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -318,6 +330,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -330,6 +344,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -342,6 +358,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         { key: '10', type: 'reservation', data: reservations[1] },
@@ -356,6 +374,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -368,6 +388,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -380,6 +402,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -392,6 +416,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -404,6 +430,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -416,6 +444,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
         {
@@ -428,6 +458,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: true,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions.minPeriod,
+            maxPeriod: timeRestrictions.maxPeriod,
           },
         },
       ];
@@ -453,6 +485,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -465,6 +499,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -477,6 +513,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -489,6 +527,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         { key: '4', type: 'reservation', data: reservations[0] },
@@ -502,6 +542,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -514,6 +556,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -526,6 +570,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -538,6 +584,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -550,6 +598,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         { key: '10', type: 'reservation', data: reservations[1] },
@@ -564,6 +614,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -576,6 +628,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: !hasRights,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -588,6 +642,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -600,6 +656,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -612,6 +670,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -624,6 +684,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
         {
@@ -636,6 +698,8 @@ describe('shared/availability-view/utils', () => {
             isSelectable: false,
             hasStaffRights: hasRights,
             isWithinCooldown: false,
+            minPeriod: timeRestrictions2.minPeriod,
+            maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
       ];

--- a/app/shared/reservation-popover/ReservationPopover.js
+++ b/app/shared/reservation-popover/ReservationPopover.js
@@ -6,6 +6,7 @@ import Popover from 'react-bootstrap/lib/Popover';
 import moment from 'moment';
 
 import { injectT } from 'i18n/index';
+import { isDurationWithinLimits } from './reservationPopoverUtils';
 
 class ReservationPopover extends PureComponent {
   render() {
@@ -13,6 +14,10 @@ class ReservationPopover extends PureComponent {
       begin, children, end, onCancel, t, minPeriod, maxPeriod
     } = this.props;
     const reservationLength = end ? moment.duration(moment(end).diff(moment(begin))) : null;
+    const minPeriodMoment = minPeriod ? moment(minPeriod, 'hh:mm:ss') : null;
+    const maxPeriodMoment = maxPeriod ? moment(maxPeriod, 'hh:mm:ss') : null;
+    const durationWithinLimits = isDurationWithinLimits(
+      reservationLength, minPeriod, maxPeriod);
 
     const popover = (
       <Popover
@@ -29,7 +34,7 @@ class ReservationPopover extends PureComponent {
         </span>
 
         {reservationLength && (
-          <span className="reservation-popover__length">
+          <span className={`reservation-popover__length${!durationWithinLimits ? ' limit-alert' : ''}`}>
             {reservationLength.hours()
               ? `(${reservationLength.hours()}h ${reservationLength.minutes()}min)`
               : `(${reservationLength.minutes()}min)`}
@@ -38,13 +43,21 @@ class ReservationPopover extends PureComponent {
         {minPeriod && (
           <span>
               {t('ReservationPopover.minPeriod')}
-            {` ${moment(minPeriod, 'hh:mm:ss').format('H')}h`}
+            <span className="reservation-popover__period-limit">
+              {minPeriodMoment.hours()
+                ? `${minPeriodMoment.hours()}h ${minPeriodMoment.minutes()}min`
+                : `${minPeriodMoment.minutes()}min`}
+            </span>
           </span>
         )}
         {maxPeriod && (
           <span>
               {t('ReservationPopover.maxPeriod')}
-            {` ${moment(maxPeriod, 'hh:mm:ss').format('H')}h`}
+            <span className="reservation-popover__period-limit">
+              {maxPeriodMoment.hours()
+                ? `${maxPeriodMoment.hours()}h ${maxPeriodMoment.minutes()}min`
+                : `${maxPeriodMoment.minutes()}min`}
+            </span>
           </span>
         )}
 

--- a/app/shared/reservation-popover/ReservationPopover.spec.js
+++ b/app/shared/reservation-popover/ReservationPopover.spec.js
@@ -39,6 +39,43 @@ describe('shared/reservation-popover/ReservationPopover', () => {
     expect(span.text()).toBe('(30min)');
   });
 
+  test('className limit-alert is added when duration is not within limits', () => {
+    const extraProps = {
+      begin: '2016-01-01T10:00:00Z',
+      end: '2016-01-01T10:30:00Z',
+      minPeriod: '01:00:00',
+    };
+    const span = getInternalPopover(extraProps).find('.limit-alert');
+    expect(span.length).toBe(1);
+  });
+
+  describe('duration limits', () => {
+    test('renders min limit when minPeriod is given', () => {
+      const minPeriod = '01:00:00';
+      const span = getInternalPopover({ minPeriod }).find('.reservation-popover__period-limit');
+      expect(span.text()).toBe('1h 0min');
+    });
+
+    test('renders max limit when maxPeriod is given', () => {
+      const maxPeriod = '02:30:00';
+      const span = getInternalPopover({ maxPeriod }).find('.reservation-popover__period-limit');
+      expect(span.text()).toBe('2h 30min');
+    });
+
+    test('renders both limits when both maxPeriod and minPeriod are given', () => {
+      const minPeriod = '00:30:00';
+      const maxPeriod = '02:00:00';
+      const spans = getInternalPopover({ minPeriod, maxPeriod }).find('.reservation-popover__period-limit');
+      expect(spans.at(0).text()).toBe('30min');
+      expect(spans.at(1).text()).toBe('2h 0min');
+    });
+
+    test('renders no limits when both max and min period are not given', () => {
+      const span = getInternalPopover().find('.reservation-popover__limits');
+      expect(span.length).toBe(0);
+    });
+  });
+
   test('renders cancel icon', () => {
     const onCancel = () => null;
     const icon = getInternalPopover({ onCancel }).find('.reservation-popover__cancel');

--- a/app/shared/reservation-popover/_reservation-popover.scss
+++ b/app/shared/reservation-popover/_reservation-popover.scss
@@ -15,5 +15,14 @@
 
   &__length {
     color: $brand-primary;
+
+    &.limit-alert {
+      color: $varaamo-high-contrast-red;
+    }
+  }
+
+  &__period-limit {
+    display: block;
+    text-align: center;
   }
 }

--- a/app/shared/reservation-popover/reservationPopoverUtils.js
+++ b/app/shared/reservation-popover/reservationPopoverUtils.js
@@ -1,0 +1,27 @@
+import moment from 'moment';
+
+/**
+ * Checks if given duration is within given min and max period limits.
+ * @param {object} duration moment duration obj
+ * @param {string} minPeriod - format HH:mm:ss, e.g. '08:00:00' or '00:30:00'
+ * @param {string} maxPeriod - format HH:mm:ss, e.g. '08:00:00' or '00:30:00'
+ * @returns {boolean} true if duration is within limits, false otherwise.
+ */
+export function isDurationWithinLimits(duration, minPeriod, maxPeriod) {
+  if (!duration) return true;
+
+  const durMinutes = duration.asMinutes();
+  const timeFormat = 'HH:mm:ss';
+
+  if (minPeriod && maxPeriod) {
+    return durMinutes >= moment.duration(minPeriod, timeFormat).asMinutes()
+     && durMinutes <= moment.duration(maxPeriod, timeFormat).asMinutes();
+  }
+  if (minPeriod) {
+    return (durMinutes >= moment.duration(minPeriod, timeFormat).asMinutes());
+  }
+  if (maxPeriod) {
+    return (durMinutes <= moment.duration(maxPeriod, timeFormat).asMinutes());
+  }
+  return true;
+}

--- a/app/shared/reservation-popover/reservationPopoverUtils.spec.js
+++ b/app/shared/reservation-popover/reservationPopoverUtils.spec.js
@@ -1,0 +1,49 @@
+import moment from 'moment';
+
+import { isDurationWithinLimits } from './reservationPopoverUtils';
+
+describe('reservationPopoverUtils', () => {
+  const begin = '2019-02-20T09:00:00';
+  const end = '2019-02-20T10:30:00';
+  const duration = moment.duration(moment(end).diff(moment(begin)));
+  describe('isDurationWithinLimits', () => {
+    test('return true when min and max are not defined', () => {
+      expect(isDurationWithinLimits(duration, null, null)).toBe(true);
+    });
+
+    test('return true when duration is undefined', () => {
+      expect(isDurationWithinLimits(null, null, null)).toBe(true);
+    });
+
+    describe('when minPeriod and maxPeriod are defined', () => {
+      test('return true when duration is within limits', () => {
+        expect(isDurationWithinLimits(duration, '01:30:00', '02:00:00')).toBe(true);
+      });
+
+      test('return false when duration is out of limits', () => {
+        expect(isDurationWithinLimits(duration, '00:30:00', '01:00:00')).toBe(false);
+        expect(isDurationWithinLimits(duration, '02:30:00', '03:00:00')).toBe(false);
+      });
+    });
+
+    describe('when minPeriod is defined', () => {
+      test('return true when duration is within limits', () => {
+        expect(isDurationWithinLimits(duration, '01:30:00', null)).toBe(true);
+      });
+
+      test('return false when duration is out of limits', () => {
+        expect(isDurationWithinLimits(duration, '02:30:00', null)).toBe(false);
+      });
+    });
+
+    describe('when maxPeriod is defined', () => {
+      test('return true when duration is within limits', () => {
+        expect(isDurationWithinLimits(duration, null, '02:00:00')).toBe(true);
+      });
+
+      test('return false when duration is out of limits', () => {
+        expect(isDurationWithinLimits(duration, null, '01:00:00')).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Added min&max period info for my premises ext resource reservation creation

Changes:
- selecting external resource slots will now display min and max period limits for the to be reservation in a popover element along reservation duration info
- external resource slot selecting will also apply red color to duration when min or max limit is not met

[Related Trello card](https://trello.com/c/UzcpUeIi)