### PR TITLE
Changed when reservation type is shown and selectable

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -22,6 +22,7 @@ class ReservationInformation extends Component {
     currentCustomerGroup: PropTypes.string.isRequired,
     currentPaymentMethod: PropTypes.string.isRequired,
     isAdmin: PropTypes.bool.isRequired,
+    isStaff: PropTypes.bool.isRequired,
     isEditing: PropTypes.bool.isRequired,
     isMakingReservations: PropTypes.bool.isRequired,
     onBack: PropTypes.func.isRequired,
@@ -47,6 +48,7 @@ class ReservationInformation extends Component {
   getFormFields = (termsAndConditions) => {
     const {
       isAdmin,
+      isStaff,
       resource,
       order,
       reservation,
@@ -69,7 +71,6 @@ class ReservationInformation extends Component {
 
     if (isAdmin) {
       formFields.push('comments');
-      formFields.push('type');
 
       /* waiting for backend implementation */
       // formFields.push('reserverName');
@@ -82,6 +83,9 @@ class ReservationInformation extends Component {
       formFields.push('staffEvent');
     }
     */
+    if (isStaff) {
+      formFields.push('type');
+    }
 
     if (termsAndConditions) {
       formFields.push('termsAndConditions');

--- a/app/pages/reservation/reservation-information/ReservationInformation.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.spec.js
@@ -163,9 +163,7 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
         const wrapper = getWrapper({ isAdmin: true, resource });
         const instance = wrapper.instance();
         const actual = instance.getFormFields();
-        // const adminFields = ['comments',
-        // 'reserverName', 'reserverEmailAddress', 'reserverPhoneNumber'];
-        const adminFields = ['comments', 'type'];
+        const adminFields = ['comments'];
 
         expect(actual).toEqual([...supportedFields, ...adminFields]);
       }
@@ -184,6 +182,13 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
       }
     );
     */
+
+    test('returns type when user is staff', () => {
+      const wrapper = getWrapper({ isStaff: true, resource });
+      const instance = wrapper.instance();
+      const actual = instance.getFormFields();
+      expect(actual).toEqual([...supportedFields, 'type']);
+    });
 
     test('returns supportedReservationExtraFields and termsAndConditions', () => {
       const termsAndConditions = 'some terms and conditions';

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.js
@@ -22,6 +22,7 @@ class ConfirmReservationModal extends Component {
     isMakingReservations: PropTypes.bool.isRequired,
     isPreliminaryReservation: PropTypes.bool.isRequired,
     isStaff: PropTypes.bool.isRequired,
+    isStaffForResource: PropTypes.bool.isRequired,
     onCancel: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
@@ -47,6 +48,7 @@ class ConfirmReservationModal extends Component {
   getFormFields = (termsAndConditions) => {
     const {
       isStaff,
+      isStaffForResource,
       resource,
       showTimeControls,
     } = this.props;
@@ -56,11 +58,15 @@ class ConfirmReservationModal extends Component {
       formFields.push('begin', 'end');
     }
 
+    // general 'is_staff' perm, not tied to unit perms
     if (isStaff) {
       formFields.push('comments');
       formFields.push('reserverName');
       formFields.push('reserverEmailAddress');
       formFields.push('reserverPhoneNumber');
+    }
+    // unit staff check
+    if (isStaffForResource) {
       formFields.push('type');
     }
     if (resource.universalField && resource.universalField.length) {

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
@@ -19,6 +19,7 @@ describe('shared/reservation-confirmation/ConfirmReservationModal', () => {
     isMakingReservations: false,
     isPreliminaryReservation: false,
     isStaff: false,
+    isStaffForResource: false,
     onCancel: simple.stub(),
     onClose: simple.stub(),
     onConfirm: simple.stub(),
@@ -182,12 +183,12 @@ describe('shared/reservation-confirmation/ConfirmReservationModal', () => {
     });
 
     describe('type', () => {
-      test('is included if user is staff', () => {
-        expect(getFormFields({ isStaff: true })).toEqual(expect.arrayContaining(['type']));
+      test('is included if user is staff for resource', () => {
+        expect(getFormFields({ isStaffForResource: true })).toEqual(expect.arrayContaining(['type']));
       });
 
-      test('is not included if user is not staff', () => {
-        expect(getFormFields({ isStaff: false })).toEqual(expect.not.arrayContaining(['type']));
+      test('is not included if user is not staff for resource', () => {
+        expect(getFormFields({ isStaffForResource: false })).toEqual(expect.not.arrayContaining(['type']));
       });
     });
 

--- a/app/shared/reservation-confirmation/ReservationConfirmationContainer.js
+++ b/app/shared/reservation-confirmation/ReservationConfirmationContainer.js
@@ -25,6 +25,7 @@ export class UnconnectedReservationConfirmationContainer extends Component {
     currentLanguage: PropTypes.string.isRequired,
     isMakingReservations: PropTypes.bool.isRequired,
     isStaff: PropTypes.bool.isRequired,
+    isStaffForResource: PropTypes.bool.isRequired,
     params: PropTypes.shape({ // eslint-disable-line react/no-unused-prop-types
       id: PropTypes.string.isRequired,
     }).isRequired,
@@ -98,6 +99,7 @@ export class UnconnectedReservationConfirmationContainer extends Component {
       confirmReservationModalIsOpen,
       isMakingReservations,
       isStaff,
+      isStaffForResource,
       recurringReservations,
       reservationsToEdit,
       resource,
@@ -116,6 +118,7 @@ export class UnconnectedReservationConfirmationContainer extends Component {
         isMakingReservations={isMakingReservations}
         isPreliminaryReservation={resource.needManualConfirmation}
         isStaff={isStaff}
+        isStaffForResource={isStaffForResource}
         onCancel={actions.cancelReservationEdit}
         onClose={actions.closeConfirmReservationModal}
         onConfirm={isEditing ? this.handleEdit : this.handleReservation}

--- a/app/shared/reservation-confirmation/ReservationConfirmationContainer.spec.js
+++ b/app/shared/reservation-confirmation/ReservationConfirmationContainer.spec.js
@@ -28,6 +28,7 @@ describe('pages/resource/reservation-calendar/ReservationConfirmationContainer',
     currentLanguage: 'fi',
     isMakingReservations: false,
     isStaff: false,
+    isStaffForResource: false,
     params: { id: resource.id },
     recurringReservations: [Reservation.build()],
     reservationsToEdit: [],
@@ -60,6 +61,7 @@ describe('pages/resource/reservation-calendar/ReservationConfirmationContainer',
         expect(actualProps.isPreliminaryReservation)
           .toBe(defaultProps.resource.needManualConfirmation);
         expect(actualProps.isStaff).toBeDefined();
+        expect(actualProps.isStaffForResource).toBeDefined();
         expect(actualProps.onCancel).toBe(defaultProps.actions.cancelReservationEdit);
         expect(actualProps.onClose).toBe(defaultProps.actions.closeConfirmReservationModal);
         expect(actualProps.onConfirm).toBe(wrapper.instance().handleReservation);

--- a/app/shared/reservation-confirmation/reservationConfirmationSelector.js
+++ b/app/shared/reservation-confirmation/reservationConfirmationSelector.js
@@ -6,7 +6,7 @@ import ActionTypes from 'constants/ActionTypes';
 import FormTypes from 'constants/FormTypes';
 import ModalTypes from 'constants/ModalTypes';
 import recurringReservations from 'state/recurringReservations';
-import { isAdminSelector } from 'state/selectors/authSelectors';
+import { isAdminSelector, createIsStaffSelector } from 'state/selectors/authSelectors';
 import { createResourceSelector } from 'state/selectors/dataSelectors';
 import selectedReservationsFromStateSelector from 'state/selectors/selectedReservationsSelector';
 import modalIsOpenSelectorFactory from 'state/selectors/factories/modalIsOpenSelectorFactory';
@@ -33,6 +33,7 @@ const reservationConfirmationSelector = createStructuredSelector({
   currentLanguage: currentLanguageSelector,
   isMakingReservations: requestIsActiveSelectorFactory(ActionTypes.API.RESERVATION_POST_REQUEST),
   isStaff: isAdminSelector,
+  isStaffForResource: createIsStaffSelector(resourceSelector),
   recurringReservations: recurringReservations.selectReservations,
   reservationsToEdit: toEditSelector,
   resource: resourceSelector,

--- a/app/shared/reservation-confirmation/reservationConfirmationSelector.spec.js
+++ b/app/shared/reservation-confirmation/reservationConfirmationSelector.spec.js
@@ -42,6 +42,10 @@ describe('shared/reservation-confirmation/reservationConfirmationSelector', () =
     expect(getSelected().isStaff).toBeDefined();
   });
 
+  test('returns isStaffForResource', () => {
+    expect(getSelected().isStaffForResource).toBeDefined();
+  });
+
   test('returns recurringReservations from the state', () => {
     expect(getSelected().recurringReservations).toEqual(recurringReservations);
   });


### PR DESCRIPTION
Previously any staff could see reservation type and its selector input. Changed permissions so that only unit's staff members can see and select reservation type.

[Related Trello card](https://trello.com/c/RZloxkQQ)