### PR TITLE
Made universal field required field in my premises page

### DIFF
--- a/app/shared/reservation-confirmation/ConfirmReservationModal.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.js
@@ -134,6 +134,10 @@ class ConfirmReservationModal extends Component {
       field => camelCase(field)
     )];
 
+    if (resource.universalField && resource.universalField.length) {
+      requiredFormFields.push('universalData');
+    }
+
     if (termsAndConditions) {
       requiredFormFields.push('termsAndConditions');
     }

--- a/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
+++ b/app/shared/reservation-confirmation/ConfirmReservationModal.spec.js
@@ -215,6 +215,17 @@ describe('shared/reservation-confirmation/ConfirmReservationModal', () => {
         expect(instance.getRequiredFormFields(
           resource, null, reservationType)).toStrictEqual(['field1', 'field2']);
       });
+
+      test('returns correct array when reservation type is not blocked and resource has universalField', () => {
+        const reservationType = constants.RESERVATION_TYPE.NORMAL_VALUE;
+        const resource = Resource.build({
+          requiredReservationExtraFields: ['field1', 'field2'],
+          universalField: [UniversalField.build()],
+        });
+        const instance = getWrapper({ resource, reservationType }).instance();
+        expect(instance.getRequiredFormFields(
+          resource, null, reservationType)).toStrictEqual(['field1', 'field2', 'universalData']);
+      });
     });
 
     /* Field hidden until it is needed again

--- a/cypress/e2e/my-premises-page.cy.js
+++ b/cypress/e2e/my-premises-page.cy.js
@@ -47,6 +47,8 @@ describe('my premises page', () => {
     // fill reservation form
     cy.get('#reserverName').scrollIntoView().should('be.visible');
     cy.get('#reserverName').should('be.visible').type('Test Tester');
+    cy.get('#universalData').scrollIntoView().should('be.visible').select(1);
+    cy.get('#universalData').should('have.value', '1');
     cy.get('button').contains('Tallenna').click();
 
     // check success message


### PR DESCRIPTION
Universal field does not follow metafield requirements. Previously my premises page assumed universal field is not required. This change makes universal field always required in my premises page when a resource has universal field defined.

[Related Trello card](https://trello.com/c/MrJbfoAj)