### PR TITLE
Changed next free time btn EN text

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -436,7 +436,7 @@
   "ResourceCard.infoTitle.removeFavorite": "Remove from favorites",
   "ResourceCompactList.button.label.next": "Next premise",
   "ResourceCompactList.button.label.previous": "Previous premise",
-  "ResourceFreeTime.buttonLabel": "Search for next free time",
+  "ResourceFreeTime.buttonLabel": "Find next available time",
   "ResourceFreeTime.notificationFound": "Free time found on",
   "ResourceFreeTime.notificationNotFound": "No free time found",
   "ResourceFreeTime.searchingText": "Searching...",


### PR DESCRIPTION
Updated the resource page's next free time button's english text.

[Related Trello card](https://trello.com/c/JqUbukiR)