### PR TITLE
Fixed a slot size selecting issue in reservation edit page

### DIFF
--- a/app/pages/manage-reservations/__tests__/manageReservationsPageSelector.spec.js
+++ b/app/pages/manage-reservations/__tests__/manageReservationsPageSelector.spec.js
@@ -10,7 +10,7 @@ jest.mock('state/selectors/dataSelectors', () => {
   };
 });
 
-describe('/pages/favorites/favoritesPageSelector', () => {
+describe('/pages/manage-reservations/manageReservationsPageSelector', () => {
   function getSelector() {
     const state = getState();
     return manageReservationsPageSelector(state);
@@ -46,6 +46,14 @@ describe('/pages/favorites/favoritesPageSelector', () => {
 
   test('returns reservationsTotalCount', () => {
     expect(getSelector().reservationsTotalCount).toBeDefined();
+  });
+
+  test('returns resources', () => {
+    expect(getSelector().resources).toBeDefined();
+  });
+
+  test('returns isFetchingResource', () => {
+    expect(getSelector().isFetchingResource).toBeDefined();
   });
 
   test('returns fontSize', () => {

--- a/app/pages/manage-reservations/__tests__/manageReservationsPageUtils.spec.js
+++ b/app/pages/manage-reservations/__tests__/manageReservationsPageUtils.spec.js
@@ -1,5 +1,7 @@
 import constants from 'constants/AppConstants';
-import { getFilteredReservations, getHiddenReservationCount, getPageResultsText } from '../manageReservationsPageUtils';
+import {
+  getFilteredReservations, getHiddenReservationCount, getPageResultsText, getResourceSlotSize
+} from '../manageReservationsPageUtils';
 import Reservation from 'utils/fixtures/Reservation';
 import Resource from 'utils/fixtures/Resource';
 
@@ -109,6 +111,38 @@ describe('pages/manage-reservations/manageReservationsPageUtils', () => {
         expect(getPageResultsText(currentPage, resultsPerPage, currentPageResults, totalResults))
           .toBe(expected);
       });
+    });
+  });
+
+  describe('getResourceSlotSize', () => {
+    const resources = {
+      1: {
+        id: 'one',
+        slotSize: '01:00:00'
+      },
+      2: {
+        id: 'two',
+        slotSize: '01:30:00'
+      }
+    };
+
+    test('returns slotSize of resource', () => {
+      const resourceId = '1';
+      expect(getResourceSlotSize(resources, resourceId)).toBe('01:00:00');
+    });
+
+    test('returns empty string if resource is not found', () => {
+      const resourceId = '3';
+      expect(getResourceSlotSize(resources, resourceId)).toBe('');
+    });
+
+    test('returns empty string if resources is not given', () => {
+      const resourceId = '1';
+      expect(getResourceSlotSize(undefined, resourceId)).toBe('');
+    });
+
+    test('returns empty string if resource id is not given', () => {
+      expect(getResourceSlotSize(resources, undefined)).toBe('');
     });
   });
 });

--- a/app/pages/manage-reservations/manageReservationsPageSelector.js
+++ b/app/pages/manage-reservations/manageReservationsPageSelector.js
@@ -3,7 +3,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import ActionTypes from 'constants/ActionTypes';
 import requestIsActiveSelectorFactory from 'state/selectors/factories/requestIsActiveSelectorFactory';
 import { isAdminSelector } from 'state/selectors/authSelectors';
-import { userFavouriteResourcesSelector, unitsSelector } from 'state/selectors/dataSelectors';
+import { userFavouriteResourcesSelector, unitsSelector, resourcesSelector } from 'state/selectors/dataSelectors';
 import { currentLanguageSelector } from 'state/selectors/translationSelectors';
 import { fontSizeSelector } from '../../state/selectors/accessibilitySelectors';
 
@@ -31,6 +31,8 @@ const manageReservationsPageSelector = createStructuredSelector({
   units: unitsArraySelector,
   reservations: reservationsSelector,
   reservationsTotalCount: reservationsCountSelector,
+  resources: resourcesSelector,
+  isFetchingResource: requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   fontSize: fontSizeSelector,
 });
 

--- a/app/pages/manage-reservations/manageReservationsPageUtils.js
+++ b/app/pages/manage-reservations/manageReservationsPageUtils.js
@@ -62,3 +62,15 @@ export function getPageResultsText(currentPage, resultsPerPage, currentPageResul
   const to = resultsPerPage * currentPage + currentPageResults;
   return `${from} - ${to} / ${totalResults}`;
 }
+
+/**
+ * Gets slot size of resource
+ * @param {object} resources
+ * @param {string} resourceId
+ * @returns {string} slot size if resource is found in resources, empty string otherwise.
+ */
+export function getResourceSlotSize(resources, resourceId) {
+  const resource = !!resources && resourceId ? resources[resourceId] : undefined;
+  if (resource) return resource.slotSize;
+  return '';
+}


### PR DESCRIPTION
Previously when admin selected to edit a reservation via manage reservations page using reservation page, it was possible to select time slot incorrectly. This happened because reservation page did not get correct slot size info from manage reservations page.

This change fixes the issue by making sure slot size is given correctly when using reservation page to edit reservations.

[Related Trello card](https://trello.com/c/ZTPlb3NR)