### PR TITLE
Disabled overnight resource use in admin resources

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -32,6 +32,7 @@
   "AdminResourcesPage.favoriteTitle": "My favorites",
   "AdminResourcesPage.external.toggle": "External resources",
   "AdminResourcesPage.external.label": "External",
+  "AdminResourcesPage.label.notUsable": "Not usable on this page",
   "AvailabilityViewDateSelector.nextDay": "next day",
   "AvailabilityViewDateSelector.previousDay": "previous day",
   "CommentForm.label": "Comments:",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -32,6 +32,7 @@
   "AdminResourcesPage.favoriteTitle": "Suosikit",
   "AdminResourcesPage.external.toggle": "Ulkoiset tilat",
   "AdminResourcesPage.external.label": "Ulkoinen",
+  "AdminResourcesPage.label.notUsable": "Ei käytettävissä tällä sivulla",
   "AvailabilityViewDateSelector.nextDay": "seuraava päivä",
   "AvailabilityViewDateSelector.previousDay": "edellinen päivä",
   "CommentForm.label": "Kommentit:",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -32,6 +32,7 @@
   "AdminResourcesPage.favoriteTitle": "Egna favoriter",
   "AdminResourcesPage.external.toggle": "Externa utrymmen",
   "AdminResourcesPage.external.label": "Extern",
+  "AdminResourcesPage.label.notUsable": "Kan inte användas på denna sida",
   "AvailabilityViewDateSelector.nextDay": "följande dag",
   "AvailabilityViewDateSelector.previousDay": "föregående dag",
   "CommentForm.label": "Kommentarer:",

--- a/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js
+++ b/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js
@@ -20,15 +20,18 @@ ResourceInfo.propTypes = {
   public: PropTypes.bool.isRequired,
   hasStaffRights: PropTypes.bool,
   t: PropTypes.func.isRequired,
+  overnightReservations: PropTypes.bool.isRequired,
 };
 export function ResourceInfo(props) {
+  const { overnightReservations } = props;
   return (
     <div
       className={classNames(
         'resource-info',
         {
           'resource-info-selected': props.isSelected,
-          'is-external': !props.hasStaffRights
+          'is-external': !props.hasStaffRights,
+          'is-overnight': props.overnightReservations,
         })
     }
       title={props.name}
@@ -37,15 +40,24 @@ export function ResourceInfo(props) {
         <Link to={`/resources/${props.id}?date=${props.date}`}>{props.name}</Link>
       </div>
       <div className="details">
-        <Glyphicon glyph="user" />
-        {' '}
-        {props.peopleCapacity}
-        {!props.public && (
-          <UnpublishedLabel />
+        {!overnightReservations && (
+          <React.Fragment>
+            <Glyphicon glyph="user" />
+            {' '}
+            {props.peopleCapacity}
+            {!props.public && (
+            <UnpublishedLabel />
+            )}
+            {!props.hasStaffRights && (
+            <Label bsStyle="default" className="unpublished-label">
+              {props.t('AdminResourcesPage.external.label')}
+            </Label>
+            )}
+          </React.Fragment>
         )}
-        {!props.hasStaffRights && (
-          <Label bsStyle="default" className="unpublished-label">
-            {props.t('AdminResourcesPage.external.label')}
+        {overnightReservations && (
+          <Label bsStyle="default" className="unusable-label" title={props.t('AdminResourcesPage.label.notUsable')}>
+            {props.t('AdminResourcesPage.label.notUsable')}
           </Label>
         )}
       </div>
@@ -70,7 +82,8 @@ export function selector() {
         name: resource.name,
         peopleCapacity: resource.peopleCapacity,
         public: resource.public,
-        hasStaffRights: isAdmin || isManager || isViewer
+        hasStaffRights: isAdmin || isManager || isViewer,
+        overnightReservations: resource.overnightReservations,
       };
     }
   );

--- a/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.spec.js
+++ b/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Glyphicon } from 'react-bootstrap';
 
 import { shallowWithIntl } from 'utils/testUtils';
 import { UnconnectedResourceInfo as ResourceInfo, selector } from './ResourceInfoContainer';
@@ -21,7 +22,8 @@ function getState() {
             isAdmin: false,
             isManager: true,
             isViewer: false
-          }
+          },
+          overnightReservations: false,
         },
       },
     },
@@ -39,6 +41,7 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
       peopleCapacity: 19,
       public: true,
       hasStaffRights: true,
+      overnightReservations: false,
     };
     return shallowWithIntl(<ResourceInfo {...defaults} {...props} />);
   }
@@ -51,6 +54,11 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
   test('has selected class if isSelected', () => {
     const wrapper = getWrapper({ isSelected: true });
     expect(wrapper.is('.resource-info-selected')).toBe(true);
+  });
+
+  test('has overnight class if overnightReservations is true', () => {
+    const wrapper = getWrapper({ overnightReservations: true });
+    expect(wrapper.is('.is-overnight')).toBe(true);
   });
 
   test('renders the name and link to resource page', () => {
@@ -87,6 +95,33 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
     expect(label).toHaveLength(0);
   });
 
+  describe('when overnightReservations is true', () => {
+    test('renders unusable label', () => {
+      const label = getWrapper({ overnightReservations: true }).find(Label);
+      expect(label).toHaveLength(1);
+      expect(label.prop('bsStyle')).toBe('default');
+      expect(label.prop('className')).toBe('unusable-label');
+      expect(label.prop('title')).toBe('AdminResourcesPage.label.notUsable');
+      expect(label.prop('children')).toBe('AdminResourcesPage.label.notUsable');
+    });
+
+    test('does not render user icon', () => {
+      const icon = getWrapper({ overnightReservations: true }).find(Glyphicon);
+      expect(icon).toHaveLength(0);
+    });
+
+    test('does not render UnpublishedLabel', () => {
+      const label = getWrapper({ overnightReservations: true }).find(UnpublishedLabel);
+      expect(label).toHaveLength(0);
+    });
+
+    test('does not render external label', () => {
+      const label = getWrapper({ overnightReservations: true, hasStaffRights: false })
+        .find('.unpublished-label');
+      expect(label).toHaveLength(0);
+    });
+  });
+
   describe('selector', () => {
     function getSelected(props) {
       const defaults = { id: '123456' };
@@ -100,6 +135,7 @@ describe('shared/availability-view/ResourceInfoContainer', () => {
         peopleCapacity: 9,
         public: true,
         hasStaffRights: true,
+        overnightReservations: false,
       });
     });
   });

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.js
@@ -32,8 +32,12 @@ export function selector() {
   const timeRestrictionsSelector = createSelector(
     resourceSelector,
     resource => {
-      const { minPeriod, maxPeriod, cooldown } = resource;
-      return { minPeriod, maxPeriod, cooldown };
+      const {
+        minPeriod, maxPeriod, cooldown, overnightReservations
+      } = resource;
+      return {
+        minPeriod, maxPeriod, cooldown, overnightReservations
+      };
     }
   );
 

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/AvailabilityTimeline/AvailabilityTimelineContainer.spec.js
@@ -12,6 +12,7 @@ function getState() {
         'resource-1': {
           id: 'resource-1',
           userPermissions: {},
+          overnightReservations: false,
           reservations: [
             {
               id: 111,
@@ -47,7 +48,11 @@ function getState() {
             },
           ],
         },
-        'resource-2': { id: 'resource-2', userPermissions: {}, },
+        'resource-2': {
+          id: 'resource-2',
+          userPermissions: {},
+          overnightReservations: false,
+        },
       },
     },
   };

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.js
@@ -15,7 +15,9 @@ function getTimeSlotWidth({ startTime, endTime } = {}) {
 }
 
 function getTimelineItems(date, reservations, resourceId, timeRestrictions, hasStaffRights) {
-  const { cooldown, minPeriod, maxPeriod } = timeRestrictions;
+  const {
+    cooldown, minPeriod, maxPeriod, overnightReservations
+  } = timeRestrictions;
   // skip getting cooldowns if user has perms
   const cooldownRanges = hasStaffRights ? [] : getCooldownRanges(reservations, cooldown);
   const items = [];
@@ -25,7 +27,7 @@ function getTimelineItems(date, reservations, resourceId, timeRestrictions, hasS
   while (timePointer.isBefore(end)) {
     const reservation = reservations && reservations[reservationPointer];
     const isSlotReservation = reservation && timePointer.isSame(reservation.begin);
-    if (isSlotReservation) {
+    if (isSlotReservation && !overnightReservations) {
       items.push({
         key: String(items.length),
         type: 'reservation',
@@ -93,6 +95,11 @@ function markItemsSelectable(items, isSelectable, openingHours, external, after)
 function addSelectionData(selection, resource, items) {
   const canIgnoreOpeningHours = resource.userPermissions.canIgnoreOpeningHours;
   const reservableAfter = resource.reservableAfter;
+
+  if (resource.overnightReservations) {
+    return items;
+  }
+
   if (!selection) {
     return markItemsSelectable(
       items, true, resource.openingHours, canIgnoreOpeningHours, reservableAfter);

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js
@@ -138,6 +138,17 @@ describe('shared/availability-view/utils', () => {
       expect(actual).toEqual(expected);
     });
 
+    test('returns items as is when resource overnightReservations is true', () => {
+      const expected = getItems(false, false, false, false);
+      const resource = {
+        id: 'r1',
+        userPermissions,
+        overnightReservations: true,
+      };
+      const actual = utils.addSelectionData(null, resource, items);
+      expect(actual).toEqual(expected);
+    });
+
     test('marks not selectable if outside available hours', () => {
       const expected = getItems(false, true, false, true);
       const resource = {
@@ -464,6 +475,25 @@ describe('shared/availability-view/utils', () => {
         },
       ];
       expect(actual).toEqual(expected);
+    });
+
+    test('returns only slots when overnightReservations is true', () => {
+      const reservations = [
+        { id: 11, begin: '2016-01-01T02:00:00', end: '2016-01-01T10:00:00' },
+        { id: 12, begin: '2016-01-01T12:30:00', end: '2016-01-01T20:00:00' },
+        { id: 13, begin: '2016-01-01T20:00:00', end: '2016-01-01T20:30:00' },
+      ];
+      const timeRestrictions2 = {
+        cooldown: '01:00:00',
+        minPeriod: '00:30:00',
+        maxPeriod: '01:00:00',
+        overnightReservations: true,
+      };
+      const items = utils.getTimelineItems(
+        moment('2016-01-01T00:00:00'), reservations, '1', timeRestrictions2, hasStaffRights);
+      items.forEach(item => {
+        expect(item.type).toBe('reservation-slot');
+      });
     });
 
     test.each([true, false])('returns slots and reservations correctly when there is cooldown and hasStaffRights is %p', hasRights => {

--- a/app/shared/label/_label.scss
+++ b/app/shared/label/_label.scss
@@ -10,4 +10,10 @@
       color: #000;
     }
   }
+
+  &.unusable-label {
+    .label {
+      color: $black;
+    }
+  }
 }


### PR DESCRIPTION
Overnight reservations don't work in admin resources page. This change labels overnight resources as unusable in admin resource page and disables slot usage and displaying of reservations.

[Related Trello card](https://trello.com/c/UKRb14S8)