### PR TITLE
Changed type blocked reservations to not have cooldown

### DIFF
--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.js
@@ -4,6 +4,7 @@ import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 
 import { slotSize, slotWidth, slotMargin } from 'constants/SlotConstants';
+import constants from '../../../../constants/AppConstants';
 
 const moment = extendMoment(Moment);
 
@@ -130,7 +131,11 @@ function addSelectionData(selection, resource, items) {
 
 function getCooldownRanges(reservations, cooldown) {
   if (reservations && cooldown && cooldown !== '00:00:00') {
-    return reservations.map(reservation => moment.range(
+    // type blocked reservations don't have cooldown
+    const filteredReservations = reservations.filter(
+      reservation => reservation.type !== constants.RESERVATION_TYPE.BLOCKED_VALUE);
+
+    return filteredReservations.map(reservation => moment.range(
       moment(reservation.begin).subtract(moment.duration(cooldown)),
       moment(reservation.end).add(moment.duration(cooldown))
     ));

--- a/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js
+++ b/app/shared/availability-view/TimelineGroups/TimelineGroup/utils.spec.js
@@ -2,6 +2,7 @@ import mockDate from 'mockdate';
 import moment from 'moment';
 
 import utils from './utils';
+import constants from '../../../../constants/AppConstants';
 
 describe('shared/availability-view/utils', () => {
   describe('getTimeSlotWidth', () => {
@@ -499,6 +500,9 @@ describe('shared/availability-view/utils', () => {
     test.each([true, false])('returns slots and reservations correctly when there is cooldown and hasStaffRights is %p', hasRights => {
       const timeRestrictions2 = { cooldown: '01:00:00', minPeriod: '00:30:00', maxPeriod: '01:00:00' };
       const reservations = [
+        {
+          id: 10, begin: '2016-01-01T01:30:00', end: '2016-01-01T02:00:00', type: constants.RESERVATION_TYPE.BLOCKED_VALUE
+        },
         { id: 11, begin: '2016-01-01T02:00:00', end: '2016-01-01T10:00:00' },
         { id: 12, begin: '2016-01-01T12:30:00', end: '2016-01-01T20:00:00' },
         { id: 13, begin: '2016-01-01T20:00:00', end: '2016-01-01T20:30:00' },
@@ -549,19 +553,10 @@ describe('shared/availability-view/utils', () => {
         },
         {
           key: '3',
-          type: 'reservation-slot',
-          data: {
-            begin: moment('2016-01-01T01:30:00').format(),
-            end: moment('2016-01-01T02:00:00').format(),
-            resourceId: '1',
-            isSelectable: false,
-            hasStaffRights: hasRights,
-            isWithinCooldown: !hasRights,
-            minPeriod: timeRestrictions2.minPeriod,
-            maxPeriod: timeRestrictions2.maxPeriod,
-          },
+          type: 'reservation',
+          data: reservations[0],
         },
-        { key: '4', type: 'reservation', data: reservations[0] },
+        { key: '4', type: 'reservation', data: reservations[1] },
         {
           key: '5',
           type: 'reservation-slot',
@@ -632,8 +627,8 @@ describe('shared/availability-view/utils', () => {
             maxPeriod: timeRestrictions2.maxPeriod,
           },
         },
-        { key: '10', type: 'reservation', data: reservations[1] },
-        { key: '11', type: 'reservation', data: reservations[2] },
+        { key: '10', type: 'reservation', data: reservations[2] },
+        { key: '11', type: 'reservation', data: reservations[3] },
         {
           key: '12',
           type: 'reservation-slot',

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -651,6 +651,29 @@ describe('Utils: timeUtils', () => {
         expect(slots[3].onCooldown).toBe(false);
         expect(slots[4].onCooldown).toBe(false);
       });
+
+      test('is false when reservation is type blocked', () => {
+        const cooldown = '1:00:00';
+        twoReservations = [
+          {
+            begin: '2015-10-09T08:00:00+03:00',
+            end: '2015-10-09T09:00:00+03:00',
+            isOwn: false,
+          },
+          {
+            begin: '2015-10-09T12:00:00+03:00',
+            end: '2015-10-09T13:00:00+03:00',
+            isOwn: true,
+            type: constants.RESERVATION_TYPE.BLOCKED_VALUE,
+          }
+        ];
+        const slots = getTimeSlots(start, end, period, twoReservations, [], cooldown);
+        expect(slots[0].onCooldown).toBe(false);
+        expect(slots[1].onCooldown).toBe(true);
+        expect(slots[2].onCooldown).toBe(false);
+        expect(slots[3].onCooldown).toBe(false); // would be on cooldown if not blocked
+        expect(slots[4].onCooldown).toBe(false);
+      });
     });
   });
 

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -1,6 +1,7 @@
 
 import forEach from 'lodash/forEach';
 import map from 'lodash/map';
+import filter from 'lodash/filter';
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 
@@ -111,11 +112,14 @@ function getTimeSlots(
     )
   );
 
+  // type blocked reservations don't have cooldown
+  const filteredReservations = filter(reservations,
+    reservation => reservation.type !== constants.RESERVATION_TYPE.BLOCKED_VALUE);
   /*
     reservation cooldown range is calculated in the following way:
     cooldown range = from (begin time - cooldown) to (end time + cooldown)
   */
-  const cooldownRanges = map(reservations, reservation => moment.range(
+  const cooldownRanges = map(filteredReservations, reservation => moment.range(
     moment(reservation.begin).subtract(moment.duration(cooldown)),
     moment(reservation.end).add(moment.duration(cooldown))
   ));


### PR DESCRIPTION
Reservations of type blocked should not have cooldown. This change handles skipping blocked reservations in cooldown checks in both resource/reservation page and in admin resources page.

[Related Trello card](https://trello.com/c/b7Gk98sR)