### PR TITLE
Fixed an issue where users could skip cooldown

### DIFF
--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -554,6 +554,7 @@ describe('Utils: timeUtils', () => {
         {
           begin: '2015-10-09T10:00:00+03:00',
           end: '2015-10-09T11:00:00+03:00',
+          id: 111,
         },
       ];
       let twoReservations = [
@@ -561,17 +562,20 @@ describe('Utils: timeUtils', () => {
           begin: '2015-10-09T09:00:00+03:00',
           end: '2015-10-09T10:00:00+03:00',
           isOwn: false,
+          id: 112
         },
         {
           begin: '2015-10-09T11:00:00+03:00',
           end: '2015-10-09T12:00:00+03:00',
           isOwn: true,
+          id: 113
         }
       ];
       const reservationsToEdit = [
         {
           begin: '2015-10-09T08:30:00+03:00',
           end: '2015-10-09T09:30:00+03:00',
+          id: 123
         },
       ];
       test('is always false when cooldown is not set or it is 0', () => {
@@ -621,10 +625,10 @@ describe('Utils: timeUtils', () => {
         expect(slots[1].onCooldown).toBe(false);
         expect(slots[2].onCooldown).toBe(true);
         expect(slots[3].onCooldown).toBe(false);
-        expect(slots[4].onCooldown).toBe(false);
+        expect(slots[4].onCooldown).toBe(true);
       });
 
-      test('is true when editing with two reservations, !isOwn reservations cooldown remains', () => {
+      test('is true when editing with two reservations', () => {
         const cooldown = '1:00:00';
         twoReservations = [
           {
@@ -649,7 +653,7 @@ describe('Utils: timeUtils', () => {
         expect(slots[0].onCooldown).toBe(false);
         expect(slots[1].onCooldown).toBe(true);
         expect(slots[2].onCooldown).toBe(false);
-        expect(slots[3].onCooldown).toBe(false);
+        expect(slots[3].onCooldown).toBe(true);
         expect(slots[4].onCooldown).toBe(false);
       });
 

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -170,8 +170,8 @@ function getTimeSlots(
         The cooldown slots get a reservation but are NOT set as reserved.
 
         When editing a reservation,
-        the cooldown slots that ONLY have the users reservation are false.
-        If a cooldown slots reservation is NOT
+        the cooldown slots that ONLY have the users currently selected reservation
+        to edit are false. If a cooldown slots reservation is NOT
         the users or its shared with another reservation it remains true.
       */
       const isEditing = Boolean(reservationsToEdit.length);
@@ -181,7 +181,8 @@ function getTimeSlots(
           reservation.push(reservations[index]);
 
           if (isEditing) {
-            if (reservation.some(res => !res.isOwn)) {
+            const resToEditId = reservationsToEdit[0]?.id;
+            if (reservation.some(res => res.id !== resToEditId)) {
               onCooldown = true;
             } else {
               onCooldown = false;


### PR DESCRIPTION
When editing some own reservation, cooldown was not shown correctly on own other reservations. This change fixes the issue by showing cooldown on user's other reservations. Only the currently selected reservation to edit does not have cooldown.

[Related Trello card](https://trello.com/c/HjCL3ga9)