### PR TITLE
Added more specific reservation period collision error notification

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -245,6 +245,7 @@
   "Notifications.cannotReserveDuringMaintenance": "Cannot make reservations during maintenance.",
   "Notifications.continousFreeDaysError": "You can only select a continuous period of available days",
   "Notifications.errorMessage": "Something went wrong. Please try again in a moment.",
+  "Notifications.error.period": "The resource is not reservable at your selected time. Please choose a new time from the calendar.",
   "Notifications.loginErrorMessage": "Failed to login. Please try again in a moment.",
   "Notifications.userFetchErrorMessage": "Failed to retrieve user info. Please try again in a moment.",
   "Notifications.loginMessage": "Sign in to continue.",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -245,6 +245,7 @@
   "Notifications.cannotReserveDuringMaintenance": "Huoltotyön aikana ei voi tehdä varauksia.",
   "Notifications.continousFreeDaysError": "Voit valita vain yhtenäisen jakson vapaita päiviä",
   "Notifications.errorMessage": "Jotain meni vikaan. Yritä hetken päästä uudelleen.",
+  "Notifications.error.period": "Kohde ei ole varattavissa valitsemallasi ajalle. Valitse kalenterista uusi aika.",
   "Notifications.loginErrorMessage": "Kirjautuminen epäonnistui. Yritä hetken päästä uudelleen.",
   "Notifications.userFetchErrorMessage": "Käyttäjätietojen hakeminen epäonnistui. Yritä hetken päästä uudelleen.",
   "Notifications.loginMessage": "Kirjaudu sisään jatkaaksesi.",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -247,6 +247,7 @@
   "Notifications.cannotReserveDuringMaintenance": "Det går inte att göra reservationer under underhåll.",
   "Notifications.continousFreeDaysError": "Du kan bara välja en sammanhängande period av lediga dagar",
   "Notifications.errorMessage": "Ett fel uppstod. Försök på nytt om en liten stund.",
+  "Notifications.error.period": "Resursen är inte bokningsbar vid den valda tiden. Vänligen välj en ny tid från kalendern.",
   "Notifications.loginErrorMessage": "Inloggning misslyckades. Försök igen om en liten stund.",
   "Notifications.userFetchErrorMessage": "Användarinformations hämtning misslyckades. Försök igen om en liten stund.",
   "Notifications.loginMessage": "Logga in för att fortsätta.",

--- a/app/state/reducers/notificationsReducer.js
+++ b/app/state/reducers/notificationsReducer.js
@@ -52,6 +52,13 @@ function getErrorNotification(error) {
     };
   }
 
+  if (error.response && error.response.period) {
+    return {
+      ...defaults,
+      messageId: 'Notifications.error.period',
+    };
+  }
+
   if (error.response && error.response.detail) {
     return {
       ...defaults,

--- a/app/state/reducers/notificationsReducer.spec.js
+++ b/app/state/reducers/notificationsReducer.spec.js
@@ -199,6 +199,17 @@ describe('state/reducers/notificationReducer', () => {
         expect(actualNotifications[0].message).toEqual('some recurring error');
       });
 
+      test('show period error when period is specified', () => {
+        const action = errorAction({
+          response: {
+            period: 'some period error'
+          },
+        });
+
+        const actualNotifications = notificationsReducer(initialState, action);
+        expect(actualNotifications[0].messageId).toEqual('Notifications.error.period');
+      });
+
       test('show detail message when response is specified', () => {
         const action = errorAction({
           response: {


### PR DESCRIPTION
Instead of showing general "something went wrong" error notification, period collision errors will show new more specific error notification.

[Related Trello card](https://trello.com/c/5d5pvTH4)