### PR TITLE
Fix to overnight calendar is next blocked check

### DIFF
--- a/app/shared/overnight-calendar/OvernightCalendar.js
+++ b/app/shared/overnight-calendar/OvernightCalendar.js
@@ -118,7 +118,9 @@ function OvernightCalendar({
   });
 
   const validateAndSelect = (day, { booked, nextBooked, nextClosed }) => {
-    const isNextBlocked = (!startDate || (startDate && endDate)) && (nextBooked || nextClosed);
+    const isNextBlocked = (
+      !startDate || (startDate && endDate) || moment(day).isBefore(startDate)
+    ) && (nextBooked || nextClosed);
     const isDateDisabled = handleDisableDays({
       day,
       now,


### PR DESCRIPTION
Previously when user selected a date after a blocked date as start date and then selected a new start date before current start date on a date where start date is not allowed (i.e. next day is blocked) the check would allow this. This change fixes the issue.

[Related Trello card](https://trello.com/c/FbpghM5Q)