### PR TITLE
Changed reservation info modal confirm cash button visibility

### DIFF
--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -164,16 +164,16 @@ class ReservationInfoModal extends Component {
               {t('ReservationInfoModal.confirmButton')}
             </Button>
           )}
-          {isStaff && reservationIsEditable
-           && reservation.state === constants.RESERVATION_STATE.WAITING_FOR_CASH_PAYMENT && (
-           <Button
-             bsStyle="success"
-             className={fontSize}
-             disabled={disabled}
-             onClick={onConfirmClick}
-           >
-             {t('common.confirmCashPayment')}
-           </Button>
+          {isStaff
+            && reservation.state === constants.RESERVATION_STATE.WAITING_FOR_CASH_PAYMENT && (
+            <Button
+              bsStyle="success"
+              className={fontSize}
+              disabled={disabled}
+              onClick={onConfirmClick}
+            >
+              {t('common.confirmCashPayment')}
+            </Button>
           )}
           {showCancelButton && (
             <Button

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -336,18 +336,6 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
           expect(getConfirmButton(props)).toHaveLength(0);
         });
 
-        test('is not rendered if reservation is not editable', () => {
-          const props = {
-            isStaff: true,
-            reservationIsEditable: false,
-            reservation: {
-              ...reservation,
-              state: constants.RESERVATION_STATE.WAITING_FOR_CASH_PAYMENT
-            },
-          };
-          expect(getConfirmButton(props)).toHaveLength(0);
-        });
-
         test('is not rendered if reservation state is not "waiting_for_cash_payment"', () => {
           const props = {
             isStaff: true,


### PR DESCRIPTION
Previously info modal did not show approve cash payment button for past reservations. This change makes the button visible also for past reservations.

[Related Trello card](https://trello.com/c/Zx2Yxphy)