### PR TITLE
Changed when min period is shown on resource page

### DIFF
--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -23,7 +23,8 @@ import ResourceCalendar from 'shared/resource-calendar';
 import { injectT } from 'i18n';
 import userManager from 'utils/userManager';
 import {
-  getMaxPeriodText, getResourcePageUrl, getMinPeriodText, getEquipment
+  getMaxPeriodText, getResourcePageUrl, getMinPeriodText, getEquipment,
+  showMinPeriod
 } from 'utils/resourceUtils';
 import ReservationCalendar from './reservation-calendar';
 import ResourceHeader from './resource-header';
@@ -321,10 +322,10 @@ class UnconnectedResourcePage extends Component {
                     {!resource.externalReservationUrl && (
                     <div>
                       {/* Show reservation min period text */}
-                      {resource.minPeriod && (
-                      <div className="app-ResourcePage__content-min-period">
-                        <p>{`${t('ReservationInfo.reservationMinLength')} ${minPeriodText}`}</p>
-                      </div>
+                      {showMinPeriod(resource.minPeriod, resource.overnightReservations) && (
+                        <div className="app-ResourcePage__content-min-period">
+                          <p>{`${t('ReservationInfo.reservationMinLength')} ${minPeriodText}`}</p>
+                        </div>
                       )}
                       {/* Show reservation max period text */}
                       {resource.maxPeriod && (

--- a/app/utils/__tests__/resourceUtils.spec.js
+++ b/app/utils/__tests__/resourceUtils.spec.js
@@ -28,7 +28,9 @@ import {
   isStrongAuthSatisfied,
   isAdminForResource,
   isManagerForResource,
-  rearrangeResources
+  rearrangeResources,
+  isBelow24Hours,
+  showMinPeriod
 } from 'utils/resourceUtils';
 import { getPrettifiedPeriodUnits } from '../timeUtils';
 import Product from '../fixtures/Product';
@@ -1220,6 +1222,32 @@ describe('Utils: resourceUtils', () => {
         .toEqual(['id2', 'id1', 'id3']);
       expect(rearrangeResources(resources, []))
         .toEqual(['id1', 'id2', 'id3']);
+    });
+  });
+
+  describe('isBelow24Hours', () => {
+    test('returns true when given date is below 24 hours', () => {
+      expect(isBelow24Hours('01:00:00')).toBe(true);
+      expect(isBelow24Hours('00:00:00')).toBe(true);
+      expect(isBelow24Hours('00:30:00')).toBe(true);
+      expect(isBelow24Hours('23:00:00')).toBe(true);
+      expect(isBelow24Hours('1 00:00:00')).toBe(false);
+      expect(isBelow24Hours('1 01:00:00')).toBe(false);
+      expect(isBelow24Hours(undefined)).toBe(false);
+    });
+  });
+
+  describe('showMinPeriod', () => {
+    test('returns correct result', () => {
+      expect(showMinPeriod('01:00:00', false)).toBe(true);
+      expect(showMinPeriod('00:30:00', false)).toBe(true);
+      expect(showMinPeriod('1 00:30:00', false)).toBe(true);
+      expect(showMinPeriod(undefined, false)).toBe(false);
+      expect(showMinPeriod('01:00:00', true)).toBe(false);
+      expect(showMinPeriod('00:30:00', true)).toBe(false);
+      expect(showMinPeriod('1 00:30:00', true)).toBe(true);
+      expect(showMinPeriod(undefined, true)).toBe(false);
+      expect(showMinPeriod(undefined, undefined)).toBe(false);
     });
   });
 });

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -375,6 +375,36 @@ function rearrangeResources(resources, resourceOrder) {
   return rearranged;
 }
 
+/**
+ * Checks whether given time string is below 24 hours
+ * @param {string} timeString e.g. "01:00:00" or "1 10:00:00"
+ * @returns {boolean} true if time string is below 24 hours
+ */
+function isBelow24Hours(timeString) {
+  if (!timeString) {
+    return false;
+  }
+  const duration = moment.duration(timeString);
+  const twentyFourHours = moment.duration(24, 'hours');
+  return duration.asMilliseconds() < twentyFourHours.asMilliseconds();
+}
+
+/**
+ * Checks whether to show min period or not.
+ * @param {string} minPeriod e.g. "01:00:00" or "1 10:00:00"
+ * @param {boolean} overnightReservations is resource overnight or normal
+ * @returns {boolean} show min period or not
+ */
+function showMinPeriod(minPeriod, overnightReservations) {
+  if (minPeriod && !overnightReservations) {
+    return true;
+  }
+  if (minPeriod && overnightReservations) {
+    return !isBelow24Hours(minPeriod);
+  }
+  return false;
+}
+
 export {
   hasMaxReservations,
   isOpenNow,
@@ -398,4 +428,6 @@ export {
   isAdminForResource,
   isManagerForResource,
   rearrangeResources,
+  isBelow24Hours,
+  showMinPeriod,
 };


### PR DESCRIPTION
Previously min period was shown always when min period was defined. Now min period is not shown if resource uses overnight reservations and the min period is less than 24h.

[Related Trello card](https://trello.com/c/y4S2VojZ)