### PR TITLE
Changed universal field description in reservation form

### DIFF
--- a/app/shared/form-fields/SelectField.js
+++ b/app/shared/form-fields/SelectField.js
@@ -55,7 +55,7 @@ function getAdditionalUniversalFields(t, label, universalFieldData) {
   const { description, data } = universalFieldData;
   return (
     <React.Fragment>
-      {description && wrapper(<p>{description}</p>)}
+      {description && wrapper(<p className="preserve-rows">{description}</p>)}
       {data && data.url && wrapper(
         <img
           alt={t('ReservationForm.universalField.pictureAlt', { label })}

--- a/app/shared/form-fields/SelectField.spec.js
+++ b/app/shared/form-fields/SelectField.spec.js
@@ -157,6 +157,7 @@ describe('shared/form-fields/SelectField', () => {
       const wrapper = getWrapper({ universalFieldData });
       const element = wrapper.find('p');
       expect(element).toHaveLength(1);
+      expect(element.prop('className')).toBe('preserve-rows');
       expect(element.text()).toBe(universalFieldData.description);
     });
     test('an img element is rendered if data & data.url exists', () => {

--- a/app/shared/form-fields/_form-fields.scss
+++ b/app/shared/form-fields/_form-fields.scss
@@ -64,3 +64,7 @@
     margin-right: 4px;
   }
 }
+
+.preserve-rows {
+  white-space: pre;
+}


### PR DESCRIPTION
Previously universal field's description didn't maintain defined rows/new lines. Now the description will include new lines when they exist.

[Related Trello card](https://trello.com/c/t6ARF6wk)