### PR TITLE
Allowed spaces for phone number in reservation form

### DIFF
--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -13,7 +13,7 @@ import {
   getRequestTypeDescriptor,
   getSuccessTypeDescriptor,
 } from 'utils/apiUtils';
-import { getMissingValues, isStaffEvent } from 'utils/reservationUtils';
+import { getMissingValues, isStaffEvent, formatPhone } from 'utils/reservationUtils';
 
 function commentReservation(reservation, resource, comments) {
   const missingValues = getMissingValues(reservation);
@@ -97,6 +97,8 @@ function parseReservationData(reservation) {
     }
     return value;
   });
+
+  trimmedValues.reserverPhoneNumber = formatPhone(trimmedValues.reserverPhoneNumber);
 
   const parsed = pickBy(trimmedValues, value => value || value === 0 || typeof (value) === 'boolean');
   return JSON.stringify(decamelizeKeys(parsed));

--- a/app/utils/__tests__/phoneValidationUtil.spec.js
+++ b/app/utils/__tests__/phoneValidationUtil.spec.js
@@ -16,6 +16,13 @@ describe('Utils: phoneValidationUtil', () => {
           expect(isValidPhoneNumber('+123-123123')).toBe(false);
         });
       });
+      describe('returns true', () => {
+        test('when valid number has spaces', () => {
+          expect(isValidPhoneNumber('55 555555')).toBe(true);
+          expect(isValidPhoneNumber('32 123123')).toBe(true);
+          expect(isValidPhoneNumber('32 123 123')).toBe(true);
+        });
+      });
     });
 
     describe('when number does not contains non numbers excluding first + char', () => {

--- a/app/utils/__tests__/reservationUtils.spec.js
+++ b/app/utils/__tests__/reservationUtils.spec.js
@@ -31,6 +31,7 @@ import {
   isManuallyConfirmedWithOrderAllowed,
   normalizeUniversalFieldOptions,
   mapReservationErrors,
+  formatPhone
 } from 'utils/reservationUtils';
 import { buildAPIUrl, getHeadersCreator } from '../apiUtils';
 import Product from '../fixtures/Product';
@@ -795,6 +796,13 @@ describe('Utils: reservationUtils', () => {
           },
         ]);
       });
+    });
+  });
+
+  describe('formatPhone', () => {
+    test('removes all whitespace characters from phone number', () => {
+      const phone = '  040 1234567  ';
+      expect(formatPhone(phone)).toBe('0401234567');
     });
   });
 });

--- a/app/utils/phoneValidationUtil.js
+++ b/app/utils/phoneValidationUtil.js
@@ -1,8 +1,8 @@
 import { PhoneNumberUtil } from 'google-libphonenumber';
 
 export function isValidPhoneNumber(number) {
-  // only allow numbers and + if its the first char
-  const regex = /^([+]\d*|\d*)$/;
+  // only allow numbers, spaces and + if it's the first char
+  const regex = /^(\+?\d[\d\s]*)$/;
   if (regex.test(number) === false) {
     return false;
   }

--- a/app/utils/reservationUtils.js
+++ b/app/utils/reservationUtils.js
@@ -418,6 +418,16 @@ function mapReservationErrors(errors, universalFields) {
   return mappedErrors.sort((a, b) => a.order - b.order);
 }
 
+/**
+ * Formats given phone number by removing all whitespace characters
+ * @param {string} phoneNum
+ * @returns {string} formatted phone number
+ */
+function formatPhone(phoneNum) {
+  if (!phoneNum) return phoneNum;
+  return phoneNum.replace(/\s/g, '');
+}
+
 export {
   combine,
   isStaffEvent,
@@ -443,4 +453,5 @@ export {
   isManuallyConfirmedWithOrderAllowed,
   normalizeUniversalFieldOptions,
   mapReservationErrors,
+  formatPhone,
 };


### PR DESCRIPTION
Spaces for phone number are now allowed. The number is later formatted to not include spaces when it's sent to Respa.

[Related Trello card](https://trello.com/c/71DtTlUc)