### PR TITLE
Fix to resource reservable before daylight savings handling

### DIFF
--- a/app/pages/resource/reservation-calendar/ReservingRestrictedText.js
+++ b/app/pages/resource/reservation-calendar/ReservingRestrictedText.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { injectT } from 'i18n';
+import { getNaiveDate } from '../../../utils/resourceUtils';
 
 function ReservingRestrictedText({
   reservableAfter, reservableBefore, reservableDaysInAdvance, t
@@ -10,7 +11,8 @@ function ReservingRestrictedText({
   const dateFormat = 'D.M.YYYY';
   const today = moment().format(dateFormat);
   const from = reservableAfter ? moment(reservableAfter).format(dateFormat) : today;
-  const until = moment(reservableBefore).subtract(1, 'day').format(dateFormat);
+  const reservableDate = moment(getNaiveDate(reservableBefore), 'YYYY-MM-DD');
+  const until = reservableDate.subtract(1, 'days').format(dateFormat);
 
   return (
     <p className="info-text">

--- a/app/utils/__tests__/resourceUtils.spec.js
+++ b/app/utils/__tests__/resourceUtils.spec.js
@@ -30,7 +30,8 @@ import {
   isManagerForResource,
   rearrangeResources,
   isBelow24Hours,
-  showMinPeriod
+  showMinPeriod,
+  getNaiveDate
 } from 'utils/resourceUtils';
 import { getPrettifiedPeriodUnits } from '../timeUtils';
 import Product from '../fixtures/Product';
@@ -1116,6 +1117,30 @@ describe('Utils: resourceUtils', () => {
         expect(isLimited).toBe(true);
         expect(reservingIsRestricted(resource, reservableBefore)).toBe(true);
       });
+    });
+  });
+
+  describe('getNaiveDate', () => {
+    test('returns the date part of a valid datetime string', () => {
+      expect(getNaiveDate('2024-11-03T00:00:00+03:00')).toBe('2024-11-03');
+    });
+
+    test('returns an empty string for falsy values', () => {
+      expect(getNaiveDate('')).toBe('');
+      expect(getNaiveDate(null)).toBe('');
+      expect(getNaiveDate(undefined)).toBe('');
+    });
+
+    test('handles datetime strings without timezone information', () => {
+      expect(getNaiveDate('2024-11-03T00:00:00')).toBe('2024-11-03');
+    });
+
+    test('handles datetime strings with milliseconds', () => {
+      expect(getNaiveDate('2024-11-03T00:00:00.123Z')).toBe('2024-11-03');
+    });
+
+    test('returns the entire string if it does not contain a "T" separator', () => {
+      expect(getNaiveDate('2024-11-03')).toBe('2024-11-03');
     });
   });
 

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -288,8 +288,19 @@ function reservingIsRestricted(resource, date) {
     return false;
   }
   const isAdmin = resource.userPermissions && resource.userPermissions.isAdmin;
-  const isLimited = resource.reservableBefore && moment(resource.reservableBefore).isSameOrBefore(moment(date), 'day');
+  const isLimited = resource.reservableBefore
+    && moment(getNaiveDate(resource.reservableBefore), 'YYYY-MM-DD').isSameOrBefore(moment(date), 'day');
   return Boolean(isLimited && !isAdmin);
+}
+
+/**
+ * Returns naive date part of the datetime string.
+ * @param {string} datetime e.g. 2024-11-03T00:00:00+03:00
+ * @returns {string} e.g. 2024-11-03 or empty string if datetime is falsy
+ */
+function getNaiveDate(datetime) {
+  if (datetime) return datetime.split('T')[0];
+  return '';
 }
 
 /**
@@ -430,4 +441,5 @@ export {
   rearrangeResources,
   isBelow24Hours,
   showMinPeriod,
+  getNaiveDate,
 };


### PR DESCRIPTION
In resource page the reservable before limit could cause an issue where limit is one day too early due to daylight savings time change. This change addresses the issue.