### PR TITLE
Environment fixes

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -1,8 +1,18 @@
 import themeConstants from '@city-assets/constants';
 
+// Ensure values from SETTINGS are always strings (never objects) so they are safe to use in URLs.
+// Prefer window.__SETTINGS__ (server-injected);
+// fall back to SETTINGS (DefinePlugin) only when type is string.
+function safeString(key, fallback = '') {
+  // eslint-disable-next-line no-underscore-dangle
+  const fromWindow = typeof window !== 'undefined' && window.__SETTINGS__ && window.__SETTINGS__[key];
+  if (typeof fromWindow === 'string') return fromWindow;
+  const fromSettings = typeof SETTINGS !== 'undefined' && SETTINGS && SETTINGS[key];
+  return typeof fromSettings === 'string' ? fromSettings : fallback;
+}
 
 const constants = {
-  API_URL: SETTINGS.API_URL,
+  API_URL: safeString('API_URL'),
   CUSTOMIZATIONS: {
     'varaamo.espoo.fi': 'ESPOO',
     'varaamotest-espoo.hel.ninja': 'ESPOO',
@@ -32,7 +42,7 @@ const constants = {
   NAV_ADMIN_URLS: {
     gitbook: 'https://city-of-turku.gitbook.io/varaamo-turku/',
     gitbook_sv: 'https://city-of-turku.gitbook.io/varaamo-turku/v/v.1.0.0-swedish/',
-    respa: SETTINGS.ADMIN_URL,
+    respa: safeString('ADMIN_URL'),
   },
   NOTIFICATION_DEFAULTS: {
     message: '',

--- a/app/pages/auth/LoginCallback.js
+++ b/app/pages/auth/LoginCallback.js
@@ -15,11 +15,9 @@ class UnconnectedLoginCallback extends React.Component {
   }
 
   loginSuccessful(user) {
-    if (user.state) {
-      this.props.history.push(user.state.redirectUrl);
-    } else {
-      this.props.history.push('/');
-    }
+    const redirectUrl = user.state && (user.state.data?.redirectUrl ?? user.state.redirectUrl);
+    const isValidPath = typeof redirectUrl === 'string' && redirectUrl.startsWith('/') && !redirectUrl.includes('[object');
+    this.props.history.push(isValidPath ? redirectUrl : '/');
   }
 
   loginUnsuccessful() {

--- a/app/pages/reservation/ReservationPage.js
+++ b/app/pages/reservation/ReservationPage.js
@@ -88,7 +88,7 @@ class UnconnectedReservationPage extends Component {
       const query = queryString.parse(location.search);
 
       if (!query.id && query.resource) {
-        history.replace(`/resources/${query.resource}`);
+        history.replace(`/resources/${String(query.resource)}`);
       } else if ('path' in query && query.path === 'manage-reservations') {
         history.replace('/manage-reservations');
       } else {
@@ -284,7 +284,7 @@ class UnconnectedReservationPage extends Component {
         history.replace('/my-reservations');
       }
     } else {
-      history.replace(`/resources/${resource.id}`);
+      history.replace(`/resources/${String(resource.id)}`);
     }
   }
 
@@ -401,7 +401,7 @@ class UnconnectedReservationPage extends Component {
  */
   handleRedirect() {
     const query = queryString.parse(this.props.location.search);
-    this.props.history.push(`/resources/${query.resource}/reservation`);
+    this.props.history.push(`/resources/${String(query.resource)}/reservation`);
   }
 
   fetchResource() {

--- a/app/pages/reservation/payment/PaymentFailed.js
+++ b/app/pages/reservation/payment/PaymentFailed.js
@@ -13,7 +13,7 @@ function PaymentFailed({
       <h2>{t('payment.title')}</h2>
       <p>{t('payment.text')}</p>
       {resourceId && (
-        <Link className="reservation-payment-failed-link" id="payment-failed-return-link" to={`/resources/${resourceId}`}>
+        <Link className="reservation-payment-failed-link" id="payment-failed-return-link" to={`/resources/${String(resourceId)}`}>
           {t('payment.link.return')}
         </Link>
       )}

--- a/app/pages/reservation/reservation-time/ReservationTime.js
+++ b/app/pages/reservation/reservation-time/ReservationTime.js
@@ -37,7 +37,7 @@ class ReservationTime extends Component {
   handleDateChange = (newDate) => {
     const { resource, history } = this.props;
     const day = newDate.toISOString().substring(0, 10);
-    history.replace(`/reservation?date=${day}&resource=${resource.id}`);
+    history.replace(`/reservation?date=${day}&resource=${String(resource.id)}`);
 
     this.setState({
       selectedDate: day

--- a/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js
+++ b/app/shared/availability-view/Sidebar/GroupInfo/ResourceInfo/ResourceInfoContainer.js
@@ -37,7 +37,7 @@ export function ResourceInfo(props) {
       title={props.name}
     >
       <div className="name">
-        <Link to={`/resources/${props.id}?date=${props.date}`}>{props.name}</Link>
+        <Link to={`/resources/${String(props.id)}?date=${props.date}`}>{props.name}</Link>
       </div>
       <div className="details">
         {!overnightReservations && (

--- a/app/state/reducers/dataReducer.js
+++ b/app/state/reducers/dataReducer.js
@@ -14,6 +14,9 @@ const initialState = Immutable({
 });
 
 function handleData(state, data) {
+  if (data == null || typeof data !== 'object') {
+    return state;
+  }
   return state.merge(data, { deep: true });
 }
 
@@ -50,7 +53,7 @@ function dataReducer(state = initialState, action) {
     }
 
     case types.API.SEARCH_RESULTS_GET_SUCCESS: {
-      return state.merge(action.payload.entities);
+      return handleData(state, action.payload.entities);
     }
 
     case types.API.RESOURCES_GET_SUCCESS: {

--- a/app/state/reducers/dataReducer.js
+++ b/app/state/reducers/dataReducer.js
@@ -53,7 +53,9 @@ function dataReducer(state = initialState, action) {
     }
 
     case types.API.SEARCH_RESULTS_GET_SUCCESS: {
-      return handleData(state, action.payload.entities);
+      const entities = action.payload.entities;
+      if (entities == null || typeof entities !== 'object') return state;
+      return state.merge(entities);
     }
 
     case types.API.RESOURCES_GET_SUCCESS: {

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -261,7 +261,7 @@ function getResourcePageUrlComponents(resource, date, time) {
   if (!resource || !resource.id) {
     return { pathname: '', query: '' };
   }
-  const pathname = `/resources/${resource.id}`;
+  const pathname = `/resources/${String(resource.id)}`;
   const query = queryString.stringify({
     date: date ? date.split('T')[0] : undefined,
     time,

--- a/app/utils/userManager.js
+++ b/app/utils/userManager.js
@@ -3,12 +3,20 @@ import { WebStorageStateStore } from 'oidc-client';
 
 const baseUrl = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}`;
 
+function safeSetting(key) {
+  // eslint-disable-next-line no-underscore-dangle
+  const fromWindow = typeof window !== 'undefined' && window.__SETTINGS__ && window.__SETTINGS__[key];
+  if (typeof fromWindow === 'string') return fromWindow;
+  const fromPlugin = typeof SETTINGS !== 'undefined' && SETTINGS && SETTINGS[key];
+  return typeof fromPlugin === 'string' ? fromPlugin : '';
+}
+
 const userManagerConfig = {
-  client_id: SETTINGS.CLIENT_ID,
+  client_id: safeSetting('CLIENT_ID'),
   redirect_uri: `${baseUrl}/callback`,
   response_type: 'id_token token',
-  scope: `openid profile ${SETTINGS.OPENID_AUDIENCE}`,
-  authority: SETTINGS.OPENID_AUTHORITY,
+  scope: `openid profile ${safeSetting('OPENID_AUDIENCE')}`,
+  authority: safeSetting('OPENID_AUTHORITY'),
   post_logout_redirect_uri: `${baseUrl}/logout/callback`,
   automaticSilentRenew: true,
   silent_redirect_uri: `${baseUrl}/silent-renew`,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -46,7 +46,7 @@ module.exports = {
     new MomentTimezoneDataPlugin({
       startYear: currentYear - 2,
       endYear: currentYear + 10,
-      matchZones: JSON.stringify(process.env.APP_TIMEZONE)
+      matchZones: process.env.APP_TIMEZONE || 'Europe/Helsinki',
     }),
   ],
 };

--- a/config/webpack.production.js
+++ b/config/webpack.production.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
-require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+// Intentionally not loading .env here: one build is used for both test and prod. Runtime
+// settings come from Azure (injected as window.__SETTINGS__ by the Node server). The
+// fallback below is only used when __SETTINGS__ is absent (e.g. static HTML).
 
 const webpack = require('webpack');
 const merge = require('webpack-merge');
@@ -51,42 +53,30 @@ module.exports = merge(common, {
     ],
   },
   plugins: [
-    // Important to keep React file size down
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production'),
-      // Prod
-      // SETTINGS: {
-      //   ADMIN_URL: JSON.stringify('https://respa.turku.fi/ra'),
-      //   API_URL: JSON.stringify('https://respa.turku.fi/v1'),
-      //   SHOW_TEST_SITE_MESSAGE: Boolean(true),
-      //   TRACKING: Boolean(process.env.MATOMO_SITE_ID),
-      //   TRACKING_ID: JSON.stringify(process.env.MATOMO_SITE_ID || "3"),
-      //   CUSTOM_MUNICIPALITY_OPTIONS: process.env.CUSTOM_MUNICIPALITY_OPTIONS,
-      //   CLIENT_ID: JSON.stringify('varaamo-02582b03-7bae-4156-b069-f5fafa0f3f75'),
-      //   OPENID_AUDIENCE: JSON.stringify('https://auth.turku.fi/respa'),
-      //   OPENID_AUTHORITY: JSON.stringify('https://tunnistamo.turku.fi/openid'),
-      //   OG_IMG_URL: JSON.stringify(process.env.OG_IMG_URL || 'https://varaamo.turku.fi/static/images/aurajoki.jpg'),
-      //   COOKIE_POLICY_BASE_URL: JSON.stringify(process.env.COOKIE_POLICY_BASE_URL || 'https://varaamo.turku.fi/cookie-policy/'),
-      //   BLOCK_SEARCH_ENGINE_INDEXING: Boolean(true),
-      //   APP_TIMEZONE: JSON.stringify('Europe/Helsinki'),
-      // },
-      // Test
-      SETTINGS: {
-        ADMIN_URL: JSON.stringify('https://testirespa.turku.fi/ra'),
-        API_URL: JSON.stringify('https://testirespa.turku.fi/v1'),
-        SHOW_TEST_SITE_MESSAGE: Boolean(true),
+    // SETTINGS: use server-injected window.__SETTINGS__ at runtime
+    // fallback must be an object so SETTINGS.API_URL is always a string
+    (() => {
+      const fallback = {
+        ADMIN_URL: process.env.ADMIN_URL || 'https://respa.turku.fi/ra',
+        API_URL: process.env.API_URL || 'https://respa.turku.fi/v1',
+        SHOW_TEST_SITE_MESSAGE: Boolean(process.env.SHOW_TEST_SITE_MESSAGE),
         TRACKING: Boolean(process.env.MATOMO_SITE_ID),
-        TRACKING_ID: JSON.stringify(process.env.MATOMO_SITE_ID || "3"),
-        CUSTOM_MUNICIPALITY_OPTIONS: process.env.CUSTOM_MUNICIPALITY_OPTIONS,
-        CLIENT_ID: JSON.stringify('7f80c6cd-d10c-4345-850b-c86aec3a0e98'),
-        OPENID_AUDIENCE: JSON.stringify('https://auth.turku.fi/respa'),
-        OPENID_AUTHORITY: JSON.stringify('https://testitunnistamo.turku.fi/openid'),
-        OG_IMG_URL: JSON.stringify(process.env.OG_IMG_URL || 'https://varaamo.turku.fi/static/images/aurajoki.jpg'),
-        COOKIE_POLICY_BASE_URL: JSON.stringify(process.env.COOKIE_POLICY_BASE_URL || 'https://varaamo.turku.fi/cookie-policy/'),
-        BLOCK_SEARCH_ENGINE_INDEXING: Boolean(true),
-        APP_TIMEZONE: JSON.stringify('Europe/Helsinki'),
-      },
-    }),
+        TRACKING_ID: process.env.MATOMO_SITE_ID || '3',
+        CUSTOM_MUNICIPALITY_OPTIONS: process.env.CUSTOM_MUNICIPALITY_OPTIONS || '',
+        CLIENT_ID: process.env.CLIENT_ID || '7f80c6cd-d10c-4345-850b-c86aec3a0e98',
+        OPENID_AUDIENCE: process.env.OPENID_AUDIENCE || 'https://auth.turku.fi/respa',
+        OPENID_AUTHORITY: process.env.OPENID_AUTHORITY || 'https://tunnistamo.turku.fi/openid',
+        OG_IMG_URL: process.env.OG_IMG_URL || 'https://varaamo.turku.fi/static/images/aurajoki.jpg',
+        COOKIE_POLICY_BASE_URL: process.env.COOKIE_POLICY_BASE_URL || 'https://varaamo.turku.fi/cookie-policy/',
+        BLOCK_SEARCH_ENGINE_INDEXING: Boolean(process.env.BLOCK_SEARCH_ENGINE_INDEXING),
+        APP_TIMEZONE: process.env.APP_TIMEZONE || 'Europe/Helsinki',
+      };
+      const fallbackLiteral = `{${Object.entries(fallback).map(([k, v]) => `${k}:${typeof v === 'string' ? JSON.stringify(v) : v}`).join(',')}}`;
+      return new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production'),
+        SETTINGS: `(typeof window !== "undefined" && window.__SETTINGS__) || (${fallbackLiteral})`,
+      });
+    })(),
     new MiniCssExtractPlugin({
       filename: 'app.css',
     }),

--- a/server/Html.js
+++ b/server/Html.js
@@ -5,6 +5,10 @@ import PropTypes from 'prop-types';
 import serialize from 'serialize-javascript';
 
 class Html extends Component {
+  getSettingsHtml(settings) {
+    return `window.__SETTINGS__ = ${JSON.stringify(settings)};`;
+  }
+
   getInitialStateHtml(initialState) {
     return `window.INITIAL_STATE = ${serialize(initialState)};`;
   }
@@ -100,6 +104,9 @@ class Html extends Component {
         </head>
         <body>
           <div id="root" />
+          <script
+            dangerouslySetInnerHTML={{ __html: this.getSettingsHtml(this.props.clientSettings) }}
+          />
           <script dangerouslySetInnerHTML={{ __html: initialStateHtml }} />
           <script src={appScriptSrc} />
         </body>
@@ -114,6 +121,7 @@ Html.propTypes = {
   initialState: PropTypes.object.isRequired,
   isProduction: PropTypes.bool.isRequired,
   matomoSiteId: PropTypes.string,
+  clientSettings: PropTypes.object.isRequired,
 };
 
 export default Html;

--- a/server/config.js
+++ b/server/config.js
@@ -18,7 +18,28 @@ function getAssetHash(filePath) {
   }
 }
 
+// Injected into HTML as window.__SETTINGS__. Read from process.env at call time so Azure
+// App Service app settings (injected as env vars at runtime) are always used.
+function getClientSettings() {
+  return {
+    ADMIN_URL: process.env.ADMIN_URL || '',
+    API_URL: process.env.API_URL || '',
+    OPENID_AUTHORITY: process.env.OPENID_AUTHORITY || '',
+    OPENID_AUDIENCE: process.env.OPENID_AUDIENCE || 'https://auth.turku.fi/respa',
+    CLIENT_ID: process.env.CLIENT_ID || '',
+    SHOW_TEST_SITE_MESSAGE: Boolean(process.env.SHOW_TEST_SITE_MESSAGE === '1' || process.env.SHOW_TEST_SITE_MESSAGE === 'true'),
+    BLOCK_SEARCH_ENGINE_INDEXING: Boolean(process.env.BLOCK_SEARCH_ENGINE_INDEXING === '1' || process.env.BLOCK_SEARCH_ENGINE_INDEXING === 'true'),
+    TRACKING: Boolean(process.env.MATOMO_SITE_ID),
+    TRACKING_ID: process.env.MATOMO_SITE_ID || '3',
+    CUSTOM_MUNICIPALITY_OPTIONS: process.env.CUSTOM_MUNICIPALITY_OPTIONS || '',
+    OG_IMG_URL: process.env.OG_IMG_URL || '',
+    COOKIE_POLICY_BASE_URL: process.env.COOKIE_POLICY_BASE_URL || '',
+    APP_TIMEZONE: process.env.APP_TIMEZONE || 'Europe/Helsinki',
+  };
+}
+
 module.exports = {
+  getClientSettings,
   assetsSources: {
     appCss: (
       isProduction

--- a/server/render.js
+++ b/server/render.js
@@ -6,11 +6,13 @@ import Html from './Html';
 
 function render(req, res) {
   const initialState = {};
+  const clientSettings = config.getClientSettings();
 
   const htmlContent = ReactDOMServer.renderToStaticMarkup(
     <Html
       appCssSrc={config.assetsSources.appCss}
       appScriptSrc={config.assetsSources.appJs}
+      clientSettings={clientSettings}
       initialState={initialState}
       isProduction={config.isProduction}
       matomoSiteId={config.matomoSiteId}

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,15 @@ if (window.Cypress) {
 
 const isIEBrowser = browserName === 'IE';
 
-if (SETTINGS.APP_TIMEZONE) {
-  moment.tz.setDefault(SETTINGS.APP_TIMEZONE);
+// eslint-disable-next-line no-underscore-dangle
+const appTimezone = (typeof window !== 'undefined' && window.__SETTINGS__ && typeof window.__SETTINGS__.APP_TIMEZONE === 'string')
+  // eslint-disable-next-line no-underscore-dangle
+  ? window.__SETTINGS__.APP_TIMEZONE
+  : 'Europe/Helsinki';
+try {
+  moment.tz.setDefault(appTimezone);
+} catch (e) {
+  // console.warn('moment timezone default zone set failed', e);
 }
 
 if (window.location.pathname === '/silent-renew') {


### PR DESCRIPTION
# Environment fixes

## Fixed env variables not actually being used

On production deploy, noticed that the environment variables do not dynamically change between test and prod environments but are hardcoded. This lead to a finding that the server defined env vars are not actually used but either a .env is used in build or the hardcoded default values in webpack.env.js. Changed the behaviour to accept env vars from server through window.

## Crawling

Using window in the past has affected SEO as headless browser might not have access to it. This integration however should work with at least Google search as it should be able to use window. Also, left production values as a fallback.